### PR TITLE
fix: Enable CoreML subgraph support for models with control flow ops

### DIFF
--- a/src/execution.rs
+++ b/src/execution.rs
@@ -5,7 +5,6 @@ use ort::session::builder::SessionBuilder;
 // GPU providers (CUDA, TensorRT, ROCm) offer 5-10x speedup but require specific hardware.
 // All GPU providers automatically fall back to CPU if they fail.
 //
-// Note: CoreML currently fails with this model due to unsupported operations.
 // WebGPU is experimental and may produce incorrect results.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ExecutionProvider {
@@ -107,6 +106,8 @@ impl ModelConfig {
                 };
                 builder.with_execution_providers([
                     CoreMLExecutionProvider::default()
+                        // Enable subgraphs for models with control flow operators.
+                        .with_subgraphs(true)
                         .with_compute_units(CoreMLComputeUnits::CPUAndGPU)
                         .build(),
                     CPUExecutionProvider::default().build().error_on_failure(),


### PR DESCRIPTION
Enable CoreML subgraph support for models with control flow operators.

This ensures the entire model graph can be executed by CoreML rather than falling back to CPU for subgraphs containing If/Loop/Scan operations.

I have tested this to be stable when using CoreML with Parakeet TDT [v2](https://huggingface.co/smcleod/parakeet-tdt-0.6b-v2-int8) and [v3](https://huggingface.co/smcleod/parakeet-tdt-0.6b-v3-int8)

With subgraphs using Parakeet TDT v2/v3 I could not reproduce #3 