### PR TITLE
fix: number-word concatenation in TDT decoder

### DIFF
--- a/src/decoder_tdt.rs
+++ b/src/decoder_tdt.rs
@@ -40,7 +40,26 @@ impl ParakeetTDTDecoder {
                 };
 
                 // Handle SentencePiece format (▁ prefix for word start)
-                let display_text = token_text.replace('▁', " ");
+                let mut display_text = token_text.replace('▁', " ");
+
+                // Insert space before pure digit tokens following words.
+                // SentencePiece digits lack the ▁ prefix, causing "at60" instead of "at 60".
+                // Skip single uppercase letters (A4, B12) but allow lowercase 'a' (article).
+                if !full_text.is_empty()
+                    && !display_text.starts_with(' ')
+                    && display_text.chars().all(|c| c.is_ascii_digit())
+                {
+                    let trailing_letters: usize = full_text
+                        .chars()
+                        .rev()
+                        .take_while(|c| c.is_alphabetic())
+                        .count();
+                    let last_char = full_text.chars().last();
+                    let is_article_a = trailing_letters == 1 && last_char == Some('a');
+                    if trailing_letters > 1 || is_article_a {
+                        display_text.insert(0, ' ');
+                    }
+                }
 
                 // Skip special tokens
                 if !(token_text.starts_with('<')
@@ -62,5 +81,114 @@ impl ParakeetTDTDecoder {
             text: full_text.trim().to_string(),
             tokens: result_tokens,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_vocab(tokens: &[&str]) -> Vocabulary {
+        Vocabulary {
+            id_to_token: tokens.iter().map(|s| s.to_string()).collect(),
+            _blank_id: 0,
+        }
+    }
+
+    #[test]
+    fn test_digit_spacing_after_word() {
+        // Simulates "like 100" tokenized as ["▁like", "1", "0", "0"]
+        let vocab = make_vocab(&["▁like", "1", "0", "0"]);
+        let decoder = ParakeetTDTDecoder::from_vocab(vocab);
+        let result = decoder
+            .decode_with_timestamps(&[0, 1, 2, 3], &[0, 1, 2, 3], &[1, 1, 1, 1], 160, 16000)
+            .unwrap();
+        assert_eq!(result.text, "like 100");
+    }
+
+    #[test]
+    fn test_digit_spacing_after_article_a() {
+        // Simulates "a 24" tokenized as ["▁a", "2", "4"]
+        let vocab = make_vocab(&["▁a", "2", "4"]);
+        let decoder = ParakeetTDTDecoder::from_vocab(vocab);
+        let result = decoder
+            .decode_with_timestamps(&[0, 1, 2], &[0, 1, 2], &[1, 1, 1], 160, 16000)
+            .unwrap();
+        assert_eq!(result.text, "a 24");
+    }
+
+    #[test]
+    fn test_no_spacing_after_single_uppercase() {
+        // Simulates "A4" tokenized as ["▁A", "4"] - should stay together
+        let vocab = make_vocab(&["▁A", "4"]);
+        let decoder = ParakeetTDTDecoder::from_vocab(vocab);
+        let result = decoder
+            .decode_with_timestamps(&[0, 1], &[0, 1], &[1, 1], 160, 16000)
+            .unwrap();
+        assert_eq!(result.text, "A4");
+    }
+
+    #[test]
+    fn test_no_spacing_after_symbol() {
+        // Simulates "$100" tokenized as ["$", "1", "0", "0"]
+        let vocab = make_vocab(&["$", "1", "0", "0"]);
+        let decoder = ParakeetTDTDecoder::from_vocab(vocab);
+        let result = decoder
+            .decode_with_timestamps(&[0, 1, 2, 3], &[0, 1, 2, 3], &[1, 1, 1, 1], 160, 16000)
+            .unwrap();
+        assert_eq!(result.text, "$100");
+    }
+
+    #[test]
+    fn test_spacing_in_phrase() {
+        // Simulates "In 2021" tokenized as ["▁In", "2", "0", "2", "1"]
+        let vocab = make_vocab(&["▁In", "2", "0", "2", "1"]);
+        let decoder = ParakeetTDTDecoder::from_vocab(vocab);
+        let result = decoder
+            .decode_with_timestamps(&[0, 1, 2, 3, 4], &[0, 1, 2, 3, 4], &[1, 1, 1, 1, 1], 160, 16000)
+            .unwrap();
+        assert_eq!(result.text, "In 2021");
+    }
+
+    #[test]
+    fn test_tokens_have_correct_spacing() {
+        // Verify individual token texts have spacing applied
+        let vocab = make_vocab(&["▁like", "1", "0", "0"]);
+        let decoder = ParakeetTDTDecoder::from_vocab(vocab);
+        let result = decoder
+            .decode_with_timestamps(&[0, 1, 2, 3], &[0, 1, 2, 3], &[1, 1, 1, 1], 160, 16000)
+            .unwrap();
+
+        // Check token texts - first digit should have space prepended
+        assert_eq!(result.tokens[0].text, " like");
+        assert_eq!(result.tokens[1].text, " 1"); // Space added by heuristic
+        assert_eq!(result.tokens[2].text, "0");
+        assert_eq!(result.tokens[3].text, "0");
+    }
+
+    #[test]
+    fn test_full_flow_with_timestamp_processing() {
+        use crate::timestamps::{process_timestamps, TimestampMode};
+
+        let vocab = make_vocab(&["▁like", "1", "0", "0", "▁bucks"]);
+        let decoder = ParakeetTDTDecoder::from_vocab(vocab);
+        let result = decoder
+            .decode_with_timestamps(
+                &[0, 1, 2, 3, 4],
+                &[0, 1, 2, 3, 4],
+                &[1, 1, 1, 1, 1],
+                160,
+                16000,
+            )
+            .unwrap();
+
+        // Test Words mode (what Undertone likely uses)
+        let words = process_timestamps(&result.tokens, TimestampMode::Words);
+        let text: String = words.iter().map(|t| t.text.as_str()).collect::<Vec<_>>().join(" ");
+        assert_eq!(text, "like 100 bucks");
+
+        // Test Tokens mode
+        let tokens_text: String = result.tokens.iter().map(|t| t.text.as_str()).collect();
+        assert_eq!(tokens_text.trim(), "like 100 bucks");
     }
 }

--- a/src/parakeet_eou.rs
+++ b/src/parakeet_eou.rs
@@ -183,9 +183,8 @@ impl ParakeetEOU {
                 self.state_c = new_c;
                 self.last_token.fill(max_idx);
 
-                if let Some(token) = self.tokenizer.id_to_token(max_idx as u32) {
-                    let clean = token.replace('▁', " ");
-                    text_output.push_str(&clean);
+                if let Ok(decoded) = self.tokenizer.decode(&[max_idx as u32], true) {
+                    text_output.push_str(&decoded);
                 }
                 syms_added += 1;
             }


### PR DESCRIPTION
Fix number-word concatenation in TDT decoder

**I'm raising this as a draft PR as I'm not sure it's the best possible fix, but it has significantly improved the transcriptions in my use case.**

## Problem

Transcription output was concatenating numbers with preceding words, e.g., `at60` instead of `at 60`. This occurred because SentencePiece digit tokens (0-9) lack the `▁` word boundary prefix.

**Examples of the issue:**
- `like100 bucks` → should be `like 100 bucks`
- `In2021` → should be `In 2021`
- `a24 compute unit` → should be `a 24 compute unit`

This did not occur when using NeMo's Python library directly with the same models.

### Root Causes

1. **TDT decoder (`decoder_tdt.rs`)**: The naive `replace('▁', " ")` approach only adds spaces where tokens have the `▁` prefix. Digit tokens lack this prefix, so no space is inserted.

2. **Timestamp processing (`timestamps.rs`)**: When the model outputs a standalone `▁` word boundary token before numbers, it was being skipped entirely. This caused subsequent digit tokens to be appended to the previous word during word grouping.

## Solution

**1. `decoder_tdt.rs`**: Added a heuristic to insert space before pure digit tokens when they follow multi-letter words:
- Inserts space after words like "like", "In", "at" before digits
- Preserves technical terms like "A4", "B12" (single uppercase letter)
- Special case for article "a" (`a 24` not `a24`)
- Does not add space after symbols (`$100` stays `$100`)

**2. `timestamps.rs`**: Space-only tokens (from `▁` word boundaries) now properly act as word separators instead of being skipped.

**3. `parakeet_eou.rs`**: Replaced manual `replace('▁', " ")` with `tokenizer.decode()` which handles SentencePiece semantics correctly.

### Testing

- Added 7 unit tests in `decoder_tdt.rs` covering digit spacing scenarios
- Added 1 unit test in `timestamps.rs` for space-token word boundary handling
- All existing tests pass
- Manually verified with Parakeet TDT v2 and v3 models

### Before/After Example

Before:

```
It might not look like much, but basically what we've got here is a cut down PlayStation5 APU. so it's capable of running triple A games.
It's got a six -core12 -thread Ryzen CPU along with a24 compute unit Radeon GPU. but the best part about these things is they are super cheap.
What we've got here is a mining blade from Hazroc, known as the AMD BC 250.
In2021, they created these using B grade PlayStation5 chips, so it's a cut down PlayStation5.
We've got six cores, twelve breads, and a24 compute unit RDNA 2.
```

After:

```
It might not look like much, but basically what we've got here is a cut -down PlayStation 5 APU. so it's capable of running AAA games.
It's got a 6 -core 12 -thread Ryzen CPU along with a 24 -compute unit Radeon GPU. but the best part about these things is they are super cheap.
What we've got here is a mining blade from Azroc, known as the AMD BC 250. in 2021, they created these using B -grade PlayStation 5 chips, so it's a cut -down PlayStation 5.
We've got six cores, 12 threads, and a 24 compute unit R DNA 2.
```

| Before                      | After                         |
|-----------------------------|-------------------------------|
| `like100 bucks to120 bucks` | `like 100 bucks to 120 bucks` |
| `a24 compute unit`          | `a 24 compute unit`           |
| `In2021`                    | `In 2021`                     |
| `PlayStation5`              | `PlayStation 5`               |
| `$100`                      | `$100` (unchanged, correct)   |
| `A4`                        | `A4` (unchanged, correct)     |

### Remaining Issue

The model tokenisation artefact of space-before-hyphen (e.g., `six -core`) as is shown in the above example is pre-existing and not addressed by this PR.
I believe it's caused by the model outputting `▁-core` which becomes ` -core`.
