### PR TITLE
refactor: wrap Arc<Mutex<NemotronModel>> in opaque NemotronHandle

### DIFF
--- a/examples/shared_model.rs
+++ b/examples/shared_model.rs
@@ -1,13 +1,13 @@
 /// Shared NemotronModel — API demo.
 ///
-/// Load the model once, create two instances with independent decoder state,
-/// and feed the same audio to both to confirm deterministic output.
+/// Load the model once via [`NemotronHandle`], create two instances with
+/// independent decoder state, and feed the same audio to both to confirm
+/// deterministic output.
 ///
 /// Usage:
 ///   cargo run --release --example shared_model <model_dir> <audio.wav>
 
 use parakeet_rs::Nemotron;
-use std::sync::Arc;
 
 fn load_wav(path: &str) -> Result<Vec<f32>, Box<dyn std::error::Error>> {
     let mut reader = hound::WavReader::open(path)?;
@@ -29,12 +29,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         std::process::exit(1);
     }
 
-    // Load the ONNX model once (~1.4 GB).
-    let (model, vocab) = Nemotron::load_model(&args[1], None)?;
+    // Load the ONNX model once (~1.4 GB) into an opaque handle.
+    let handle = Nemotron::load_model(&args[1], None)?;
 
     // Create two instances sharing the model, each with independent decoder state.
-    let mut a = Nemotron::from_shared_model(Arc::clone(&model), Arc::clone(&vocab));
-    let mut b = Nemotron::from_shared_model(Arc::clone(&model), Arc::clone(&vocab));
+    let mut a = Nemotron::from_shared_model(handle.clone());
+    let mut b = Nemotron::from_shared_model(handle);
 
     let audio = load_wav(&args[2])?;
     let chunk_size = 8960; // 560 ms at 16 kHz

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ pub use model::ParakeetModel;
 pub use model_eou::ParakeetEOUModel;
 pub use model_nemotron::{NemotronEncoderCache, NemotronModel, NemotronModelConfig};
 pub use model_unified::{ParakeetUnifiedModel, UnifiedModelConfig};
-pub use nemotron::{Nemotron, SentencePieceVocab};
+pub use nemotron::{Nemotron, NemotronHandle, SentencePieceVocab};
 pub use parakeet_eou::ParakeetEOU;
 pub use parakeet_unified::{ParakeetUnified, UnifiedStreamingConfig};
 

--- a/src/nemotron.rs
+++ b/src/nemotron.rs
@@ -9,6 +9,20 @@ use std::io::Read;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
+/// Opaque handle to a loaded Nemotron model and vocabulary.
+///
+/// Cheap to clone — only reference-counted pointers are duplicated.
+/// The internal synchronisation strategy is hidden so it can change
+/// without breaking downstream code.
+///
+/// Create one via [`Nemotron::load_model`], then pass clones to
+/// [`Nemotron::from_shared_model`] for each stream.
+#[derive(Clone)]
+pub struct NemotronHandle {
+    model: Arc<Mutex<NemotronModel>>,
+    vocab: Arc<SentencePieceVocab>,
+}
+
 // Nemotron 0.6B model constants
 // note that those numbers are coming from offical impl. and of course my onnx export decisions.
 // Buffer logic and cache slicing strategy derived from:
@@ -189,13 +203,12 @@ impl SentencePieceVocab {
 /// Nemotron streaming ASR model (0.6B parameters).
 /// We dont apply mel normalization unlike others...
 ///
-/// The ONNX model is stored behind `Arc<Mutex<>>` to allow sharing a single
-/// model (~1.4GB) across multiple instances with independent decoder state.
-/// Use [`Nemotron::from_shared_model`] to create instances that share a model,
-/// or [`Nemotron::load_model`] to load the model once and share it.
+/// The ONNX model is stored behind a [`NemotronHandle`] to allow sharing a
+/// single model (~1.4GB) across multiple instances with independent decoder
+/// state. Use [`Nemotron::from_shared_model`] to create instances that share
+/// a model, or [`Nemotron::load_model`] to load the model once and share it.
 pub struct Nemotron {
-    model: Arc<Mutex<NemotronModel>>,
-    vocab: Arc<SentencePieceVocab>,
+    handle: NemotronHandle,
     encoder_cache: NemotronEncoderCache,
     state_1: Array3<f32>,
     state_2: Array3<f32>,
@@ -211,13 +224,13 @@ pub struct Nemotron {
 }
 
 impl Nemotron {
-    /// Load the ONNX model and vocabulary from a directory, returning
-    /// shareable handles. Call this once, then pass the returned `Arc`s
-    /// to [`Nemotron::from_shared_model`] for each stream.
+    /// Load the ONNX model and vocabulary from a directory, returning an
+    /// opaque [`NemotronHandle`]. Call this once, then pass clones of the
+    /// handle to [`Nemotron::from_shared_model`] for each stream.
     pub fn load_model<P: AsRef<Path>>(
         path: P,
         exec_config: Option<ExecutionConfig>,
-    ) -> Result<(Arc<Mutex<NemotronModel>>, Arc<SentencePieceVocab>)> {
+    ) -> Result<NemotronHandle> {
         let path = path.as_ref();
 
         let vocab = SentencePieceVocab::from_file(path.join("tokenizer.model"))?;
@@ -236,18 +249,18 @@ impl Nemotron {
         let exec = exec_config.unwrap_or_default();
         let model = NemotronModel::from_pretrained(path, exec, model_config)?;
 
-        Ok((Arc::new(Mutex::new(model)), Arc::new(vocab)))
+        Ok(NemotronHandle {
+            model: Arc::new(Mutex::new(model)),
+            vocab: Arc::new(vocab),
+        })
     }
 
-    /// Create a new Nemotron instance with shared model and vocabulary.
+    /// Create a new Nemotron instance with a shared [`NemotronHandle`].
     ///
     /// Each instance has independent decoder state (~7.5MB) while sharing
     /// the expensive ONNX sessions (~1.4GB). The model Mutex is held only
     /// during encoder/decoder inference (~20-50ms per 560ms audio chunk).
-    pub fn from_shared_model(
-        model: Arc<Mutex<NemotronModel>>,
-        vocab: Arc<SentencePieceVocab>,
-    ) -> Self {
+    pub fn from_shared_model(handle: NemotronHandle) -> Self {
         let encoder_cache = NemotronEncoderCache::with_dims(
             NUM_ENCODER_LAYERS,
             LEFT_CONTEXT,
@@ -256,8 +269,7 @@ impl Nemotron {
         );
 
         Self {
-            model,
-            vocab,
+            handle,
             encoder_cache,
             state_1: Array3::zeros((2, 1, DECODER_LSTM_DIM)),
             state_2: Array3::zeros((2, 1, DECODER_LSTM_DIM)),
@@ -281,8 +293,8 @@ impl Nemotron {
         path: P,
         exec_config: Option<ExecutionConfig>,
     ) -> Result<Self> {
-        let (model, vocab) = Self::load_model(path, exec_config)?;
-        Ok(Self::from_shared_model(model, vocab))
+        let handle = Self::load_model(path, exec_config)?;
+        Ok(Self::from_shared_model(handle))
     }
 
     /// Reset all state for new utterance
@@ -310,7 +322,7 @@ impl Nemotron {
             .filter(|&&t| t < VOCAB_SIZE)
             .copied()
             .collect();
-        self.vocab.decode(&valid)
+        self.handle.vocab.decode(&valid)
     }
 
     /// note that, offline transcription for testing/debugging and for some curious ppl :-). with following function too (transcribe_audio)
@@ -374,7 +386,7 @@ impl Nemotron {
             let chunk_length = PRE_ENCODE_CACHE + main_len;
 
             let (encoded, enc_len, new_cache) = {
-                let mut model = self.model.lock().map_err(|e| {
+                let mut model = self.handle.model.lock().map_err(|e| {
                     Error::Model(format!("Failed to acquire model lock: {e}"))
                 })?;
                 model.run_encoder(&mel_chunk, chunk_length as i64, &self.encoder_cache)?
@@ -390,7 +402,7 @@ impl Nemotron {
 
         let valid_tokens: Vec<usize> = all_tokens.into_iter().filter(|&t| t < VOCAB_SIZE).collect();
 
-        Ok(self.vocab.decode(&valid_tokens))
+        Ok(self.handle.vocab.decode(&valid_tokens))
     }
 
     /// Stream transcribe a chunk of audio (call repeatedly for real-time).
@@ -466,7 +478,7 @@ impl Nemotron {
             .map_err(|e| Error::Model(format!("Failed to create mel chunk: {e}")))?;
 
         let (encoded, enc_len, new_cache) = {
-            let mut model = self.model.lock().map_err(|e| {
+            let mut model = self.handle.model.lock().map_err(|e| {
                 Error::Model(format!("Failed to acquire model lock: {e}"))
             })?;
             model.run_encoder(&mel_chunk, expected_size as i64, &self.encoder_cache)?
@@ -494,7 +506,7 @@ impl Nemotron {
         let mut result = String::new();
         for &t in &tokens {
             if t < VOCAB_SIZE {
-                result.push_str(&self.vocab.decode_single(t));
+                result.push_str(&self.handle.vocab.decode_single(t));
             }
         }
         Ok(result)
@@ -507,7 +519,7 @@ impl Nemotron {
 
         // Lock the model once for the entire decode loop to minimise
         // lock acquire/release overhead (many decoder steps per chunk).
-        let mut model = self.model.lock().map_err(|e| {
+        let mut model = self.handle.model.lock().map_err(|e| {
             Error::Model(format!("Failed to acquire model lock: {e}"))
         })?;
 
@@ -629,5 +641,24 @@ impl Nemotron {
         (0..WIN_LENGTH)
             .map(|i| 0.5 - 0.5 * ((2.0 * PI * i as f32) / ((WIN_LENGTH - 1) as f32)).cos())
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_send_sync_clone<T: Send + Sync + Clone>() {}
+
+    #[test]
+    fn nemotron_handle_is_send_sync_clone() {
+        assert_send_sync_clone::<NemotronHandle>();
+    }
+
+    #[test]
+    fn nemotron_handle_fields_are_private() {
+        // NemotronHandle can only be constructed via Nemotron::load_model —
+        // there is no way to name its fields from outside this module.
+        // This test exists as a compile-time contract reminder.
     }
 }


### PR DESCRIPTION
## Summary

Following up on your suggestion from the shared model PR review:

> I realized that on my second review, load_model exposes Arc<Mutex> in its
> return type, which pins the sync strategy into the public API. I'm thinking
> wrapping those in an opaque NemotronHandle would let us swap the internals
> later without breakage.

Thought this was a great call and straightforward enough to knock out quickly!

`NemotronHandle` is an opaque newtype wrapping the model and vocabulary Arcs.
It's `Clone + Send + Sync` with private fields, so the internal locking
strategy can evolve freely without affecting downstream code.

### What changed

- `load_model` returns `NemotronHandle` instead of a raw `(Arc<Mutex<…>>, Arc<…>)` tuple
- `from_shared_model` takes a single `NemotronHandle` instead of two separate Arc params
- `shared_model` example simplified — `handle.clone()` replaces manual `Arc::clone` calls
- Added compile-time trait bound tests for `Send + Sync + Clone`

### Breaking changes

- `Nemotron::load_model` return type changed
- `Nemotron::from_shared_model` signature changed

No version bump included — happy to leave that to you for whenever you're
ready to cut a release.

## Test plan

- [x] `cargo check` — clean, zero warnings
- [x] `cargo test` — 17/17 pass
- [x] `shared_model` example updated and compiles