### PR TITLE
Extend shared session API to other streaming models

### DIFF
--- a/examples/shared_model.rs
+++ b/examples/shared_model.rs
@@ -1,44 +1,52 @@
-/// Shared NemotronModel — API demo.
-///
-/// Load the model once, create two instances with independent decoder state,
-/// and feed the same audio to both to confirm deterministic output.
-///
-/// Usage:
-///   cargo run --release --example shared_model <model_dir> <audio.wav>
+/*
+Shared-model demo — load one ONNX session, drive two concurrent streams
+with independent decoder state for streaming models:
+Nemotron (default):
+cargo run --release --example shared_model ./nemotron audio.wav
 
-use parakeet_rs::Nemotron;
-use std::sync::Arc;
+EOU:
+cargo run --release --example shared_model ./fullstr audio.wav eou
+
+Unified:
+cargo run --release --example shared_model ./unified audio.wav unified
+
+---
+
+Nemotron (600M): https://huggingface.co/altunenes/parakeet-rs/tree/main/nemotron-speech-streaming-en-0.6b
+EOU (120M): https://huggingface.co/altunenes/parakeet-rs/tree/main/realtime_eou_120m-v1-onnx
+Unified: https://huggingface.co/bobNight/parakeet-unified-en-0.6b-onnx/tree/main
+*/
+
+use parakeet_rs::{
+    Nemotron, NemotronHandle, ParakeetEOU, ParakeetEOUHandle, ParakeetUnified,
+    ParakeetUnifiedHandle,
+};
 
 fn load_wav(path: &str) -> Result<Vec<f32>, Box<dyn std::error::Error>> {
     let mut reader = hound::WavReader::open(path)?;
     let spec = reader.spec();
-    let audio: Vec<f32> = match spec.sample_format {
+    let mut audio: Vec<f32> = match spec.sample_format {
         hound::SampleFormat::Float => reader.samples::<f32>().collect::<Result<_, _>>()?,
         hound::SampleFormat::Int => reader
             .samples::<i16>()
             .map(|s| s.map(|v| v as f32 / 32768.0))
             .collect::<Result<_, _>>()?,
     };
+    if spec.channels > 1 {
+        audio = audio
+            .chunks(spec.channels as usize)
+            .map(|c| c.iter().sum::<f32>() / spec.channels as f32)
+            .collect();
+    }
     Ok(audio)
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let args: Vec<String> = std::env::args().collect();
-    if args.len() < 3 {
-        eprintln!("Usage: shared_model <model_dir> <audio.wav>");
-        std::process::exit(1);
-    }
+fn run_nemotron(model_dir: &str, audio: &[f32]) -> Result<(), Box<dyn std::error::Error>> {
+    let handle = NemotronHandle::load(model_dir, None)?;
+    let mut a = Nemotron::from_shared(&handle);
+    let mut b = Nemotron::from_shared(&handle);
 
-    // Load the ONNX model once (~1.4 GB).
-    let (model, vocab) = Nemotron::load_model(&args[1], None)?;
-
-    // Create two instances sharing the model, each with independent decoder state.
-    let mut a = Nemotron::from_shared_model(Arc::clone(&model), Arc::clone(&vocab));
-    let mut b = Nemotron::from_shared_model(Arc::clone(&model), Arc::clone(&vocab));
-
-    let audio = load_wav(&args[2])?;
     let chunk_size = 8960; // 560 ms at 16 kHz
-
     for chunk_data in audio.chunks(chunk_size) {
         let mut chunk = chunk_data.to_vec();
         chunk.resize(chunk_size, 0.0);
@@ -48,7 +56,81 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("A: {}", a.get_transcript());
     println!("B: {}", b.get_transcript());
-    assert_eq!(a.get_transcript(), b.get_transcript(), "shared model must be deterministic");
-    println!("OK — both instances produced identical output");
+    assert_eq!(
+        a.get_transcript(),
+        b.get_transcript(),
+        "shared model must be deterministic"
+    );
+    println!("same");
     Ok(())
+}
+
+fn run_eou(model_dir: &str, audio: &[f32]) -> Result<(), Box<dyn std::error::Error>> {
+    let handle = ParakeetEOUHandle::load(model_dir, None)?;
+    let mut a = ParakeetEOU::from_shared(&handle);
+    let mut b = ParakeetEOU::from_shared(&handle);
+
+    let chunk_size = 2560;
+    let mut a_text = String::new();
+    let mut b_text = String::new();
+    for chunk_data in audio.chunks(chunk_size) {
+        let chunk: Vec<f32> = if chunk_data.len() < chunk_size {
+            let mut p = chunk_data.to_vec();
+            p.resize(chunk_size, 0.0);
+            p
+        } else {
+            chunk_data.to_vec()
+        };
+        a_text.push_str(&a.transcribe(&chunk, false)?);
+        b_text.push_str(&b.transcribe(&chunk, false)?);
+    }
+
+    println!("A: {}", a_text.trim());
+    println!("B: {}", b_text.trim());
+    assert_eq!(a_text, b_text, "shared model must be deterministic");
+    println!("same");
+    Ok(())
+}
+
+fn run_unified(model_dir: &str, audio: &[f32]) -> Result<(), Box<dyn std::error::Error>> {
+    let handle = ParakeetUnifiedHandle::load(model_dir, None)?;
+    let mut a = ParakeetUnified::from_shared(&handle);
+    let mut b = ParakeetUnified::from_shared(&handle);
+
+    let chunk_size = a.streaming_config().chunk_samples();
+    for chunk_data in audio.chunks(chunk_size) {
+        a.transcribe_chunk(chunk_data)?;
+        b.transcribe_chunk(chunk_data)?;
+    }
+    a.flush()?;
+    b.flush()?;
+
+    println!("A: {}", a.get_transcript());
+    println!("B: {}", b.get_transcript());
+    assert_eq!(
+        a.get_transcript(),
+        b.get_transcript(),
+        "shared model must be deterministic"
+    );
+    println!("same");
+    Ok(())
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 3 {
+        eprintln!("Usage: shared_model <model_dir> <audio.wav> [eou|unified]");
+        std::process::exit(1);
+    }
+    let model_dir = &args[1];
+    let audio_path = &args[2];
+    let variant = args.get(3).map(String::as_str).unwrap_or("nemotron");
+
+    let audio = load_wav(audio_path)?;
+
+    match variant {
+        "eou" => run_eou(model_dir, &audio),
+        "unified" => run_unified(model_dir, &audio),
+        _ => run_nemotron(model_dir, &audio),
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,9 +87,9 @@ pub use model::ParakeetModel;
 pub use model_eou::ParakeetEOUModel;
 pub use model_nemotron::{NemotronEncoderCache, NemotronModel, NemotronModelConfig};
 pub use model_unified::{ParakeetUnifiedModel, UnifiedModelConfig};
-pub use nemotron::{Nemotron, SentencePieceVocab};
-pub use parakeet_eou::ParakeetEOU;
-pub use parakeet_unified::{ParakeetUnified, UnifiedStreamingConfig};
+pub use nemotron::{Nemotron, NemotronHandle, SentencePieceVocab};
+pub use parakeet_eou::{ParakeetEOU, ParakeetEOUHandle};
+pub use parakeet_unified::{ParakeetUnified, ParakeetUnifiedHandle, UnifiedStreamingConfig};
 
 #[cfg(feature = "multitalker")]
 pub use multitalker::{LatencyMode, MultitalkerASR, MultitalkerConfig, SpeakerTranscript, WordTimestamp};

--- a/src/nemotron.rs
+++ b/src/nemotron.rs
@@ -2,8 +2,6 @@ use crate::error::{Error, Result};
 use crate::execution::ModelConfig as ExecutionConfig;
 use crate::model_nemotron::{NemotronEncoderCache, NemotronModel, NemotronModelConfig};
 use ndarray::{s, Array2, Array3};
-use realfft::RealFftPlanner;
-use std::f32::consts::PI;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
@@ -186,22 +184,32 @@ impl SentencePieceVocab {
     }
 }
 
+/// Shared handle to a loaded Nemotron model.
+/// ONNX session is only loaded once and reference counted.
+///
+/// Use [`NemotronHandle::load`] to load from disk, then [`Nemotron::from_shared`]
+/// to spawn each stream with its own independent decoder state.
+#[derive(Clone)]
+pub struct NemotronHandle {
+    model: Arc<Mutex<NemotronModel>>,
+    vocab: Arc<SentencePieceVocab>,
+    mel_basis: Arc<Array2<f32>>,
+}
+
 /// Nemotron streaming ASR model (0.6B parameters).
 /// We dont apply mel normalization unlike others...
 ///
-/// The ONNX model is stored behind `Arc<Mutex<>>` to allow sharing a single
-/// model (~1.4GB) across multiple instances with independent decoder state.
-/// Use [`Nemotron::from_shared_model`] to create instances that share a model,
-/// or [`Nemotron::load_model`] to load the model once and share it.
+/// For a single stream, use [`Nemotron::from_pretrained`]. For multiple
+/// concurrent streams (e.g. mic + system audio) sharing one loaded model,
+/// use [`NemotronHandle::load`] followed by [`Nemotron::from_shared`].
 pub struct Nemotron {
     model: Arc<Mutex<NemotronModel>>,
     vocab: Arc<SentencePieceVocab>,
+    mel_basis: Arc<Array2<f32>>,
     encoder_cache: NemotronEncoderCache,
     state_1: Array3<f32>,
     state_2: Array3<f32>,
     last_token: i32,
-    mel_basis: Array2<f32>,
-    window: Vec<f32>,
     /// Raw audio sample buffer for proper mel computation
     audio_buffer: Vec<f32>,
     /// How many audio samples have been processed (converted to mel and sent to encoder)
@@ -210,14 +218,21 @@ pub struct Nemotron {
     accumulated_tokens: Vec<usize>,
 }
 
-impl Nemotron {
-    /// Load the ONNX model and vocabulary from a directory, returning
-    /// shareable handles. Call this once, then pass the returned `Arc`s
-    /// to [`Nemotron::from_shared_model`] for each stream.
-    pub fn load_model<P: AsRef<Path>>(
+impl NemotronHandle {
+    /// Load the Nemotron model and vocabulary from a directory.
+    ///
+    /// Required files in `path`:
+    /// - `encoder.onnx` + `encoder.onnx.data`
+    /// - `decoder_joint.onnx`
+    /// - `tokenizer.model`
+    ///
+    /// The returned handle is cheap to clone and can be used to spawn any
+    /// number of [`Nemotron`] instances via [`Nemotron::from_shared`], each
+    /// with its own independent decoder state.
+    pub fn load<P: AsRef<Path>>(
         path: P,
         exec_config: Option<ExecutionConfig>,
-    ) -> Result<(Arc<Mutex<NemotronModel>>, Arc<SentencePieceVocab>)> {
+    ) -> Result<Self> {
         let path = path.as_ref();
 
         let vocab = SentencePieceVocab::from_file(path.join("tokenizer.model"))?;
@@ -235,19 +250,36 @@ impl Nemotron {
 
         let exec = exec_config.unwrap_or_default();
         let model = NemotronModel::from_pretrained(path, exec, model_config)?;
+        let mel_basis = crate::audio::create_mel_filterbank(N_FFT, N_MELS, SAMPLE_RATE);
 
-        Ok((Arc::new(Mutex::new(model)), Arc::new(vocab)))
+        Ok(Self {
+            model: Arc::new(Mutex::new(model)),
+            vocab: Arc::new(vocab),
+            mel_basis: Arc::new(mel_basis),
+        })
+    }
+}
+
+impl Nemotron {
+    /// Load Nemotron from a directory and return a ready to use instance.
+    /// Convenience wrapper for the single-stream case.
+    ///
+    /// For multiple concurrent streams sharing one loaded model, use
+    /// [`NemotronHandle::load`] + [`Nemotron::from_shared`] instead.
+    pub fn from_pretrained<P: AsRef<Path>>(
+        path: P,
+        exec_config: Option<ExecutionConfig>,
+    ) -> Result<Self> {
+        Ok(Self::from_shared(&NemotronHandle::load(path, exec_config)?))
     }
 
-    /// Create a new Nemotron instance with shared model and vocabulary.
+    /// Spawn a new Nemotron instance bound to a shared model.
     ///
-    /// Each instance has independent decoder state (~7.5MB) while sharing
-    /// the expensive ONNX sessions (~1.4GB). The model Mutex is held only
-    /// during encoder/decoder inference (~20-50ms per 560ms audio chunk).
-    pub fn from_shared_model(
-        model: Arc<Mutex<NemotronModel>>,
-        vocab: Arc<SentencePieceVocab>,
-    ) -> Self {
+    /// Each instance owns independent decoder state (~7.5 MB) while the
+    /// expensive ONNX session is shared through the handle.
+    /// The model lock is held only during encoder/decoder inference
+    /// (~20-50 ms per 560 ms audio chunk).
+    pub fn from_shared(handle: &NemotronHandle) -> Self {
         let encoder_cache = NemotronEncoderCache::with_dims(
             NUM_ENCODER_LAYERS,
             LEFT_CONTEXT,
@@ -256,33 +288,18 @@ impl Nemotron {
         );
 
         Self {
-            model,
-            vocab,
+            model: Arc::clone(&handle.model),
+            vocab: Arc::clone(&handle.vocab),
+            mel_basis: Arc::clone(&handle.mel_basis),
             encoder_cache,
             state_1: Array3::zeros((2, 1, DECODER_LSTM_DIM)),
             state_2: Array3::zeros((2, 1, DECODER_LSTM_DIM)),
             last_token: BLANK_ID as i32,
-            mel_basis: crate::audio::create_mel_filterbank(N_FFT, N_MELS, SAMPLE_RATE),
-            window: Self::create_window(),
             audio_buffer: Vec::new(),
             audio_processed: 0,
             chunk_idx: 0,
             accumulated_tokens: Vec::new(),
         }
-    }
-
-    /// Load Nemotron model from directory.
-    ///
-    /// Required files:
-    /// - encoder.onnx + encoder.onnx.data
-    /// - decoder_joint.onnx
-    /// - tokenizer.model
-    pub fn from_pretrained<P: AsRef<Path>>(
-        path: P,
-        exec_config: Option<ExecutionConfig>,
-    ) -> Result<Self> {
-        let (model, vocab) = Self::load_model(path, exec_config)?;
-        Ok(Self::from_shared_model(model, vocab))
     }
 
     /// Reset all state for new utterance
@@ -557,77 +574,10 @@ impl Nemotron {
             return Ok(Array2::zeros((N_MELS, 0)));
         }
 
-        let preemph = Self::apply_preemphasis(audio);
-        let spec = self.stft_center(&preemph)?;
+        let preemph = crate::audio::apply_preemphasis(audio, PREEMPH);
+        let spec = crate::audio::stft(&preemph, N_FFT, HOP_LENGTH, WIN_LENGTH)?;
         let mel = self.mel_basis.dot(&spec);
 
-        Ok(mel.mapv(|x| (x.max(0.0) + LOG_ZERO_GUARD).ln()))
-    }
-
-    fn apply_preemphasis(audio: &[f32]) -> Vec<f32> {
-        if audio.is_empty() {
-            return Vec::new();
-        }
-
-        let mut result = Vec::with_capacity(audio.len());
-        result.push(audio[0]);
-
-        for i in 1..audio.len() {
-            let v = audio[i] - PREEMPH * audio[i - 1];
-            result.push(if v.is_finite() { v } else { 0.0 });
-        }
-
-        result
-    }
-
-    fn stft_center(&self, audio: &[f32]) -> Result<Array2<f32>> {
-        let mut planner = RealFftPlanner::<f32>::new();
-        let r2c = planner.plan_fft_forward(N_FFT);
-
-        let pad_amount = N_FFT / 2;
-        let mut padded = vec![0.0f32; pad_amount];
-        padded.extend_from_slice(audio);
-        padded.extend(std::iter::repeat_n(0.0f32, pad_amount));
-
-        let num_frames = if padded.len() >= WIN_LENGTH {
-            1 + (padded.len() - WIN_LENGTH) / HOP_LENGTH
-        } else {
-            0
-        };
-
-        let freq_bins = N_FFT / 2 + 1;
-        let mut spec = Array2::zeros((freq_bins, num_frames));
-
-        let mut input = vec![0.0f32; N_FFT];
-        let mut output = r2c.make_output_vec();
-        let mut scratch = r2c.make_scratch_vec();
-
-        for frame_idx in 0..num_frames {
-            let start = frame_idx * HOP_LENGTH;
-            if start + WIN_LENGTH > padded.len() {
-                break;
-            }
-
-            input.fill(0.0);
-            for i in 0..WIN_LENGTH {
-                input[i] = padded[start + i] * self.window[i];
-            }
-
-            r2c.process_with_scratch(&mut input, &mut output, &mut scratch)
-                .map_err(|e| Error::Audio(format!("FFT failed: {e}")))?;
-
-            for (i, val) in output.iter().take(freq_bins).enumerate() {
-                let mag_sq = val.norm_sqr();
-                spec[[i, frame_idx]] = if mag_sq.is_finite() { mag_sq } else { 0.0 };
-            }
-        }
-
-        Ok(spec)
-    }
-
-    fn create_window() -> Vec<f32> {
-        (0..WIN_LENGTH)
-            .map(|i| 0.5 - 0.5 * ((2.0 * PI * i as f32) / ((WIN_LENGTH - 1) as f32)).cos())
-            .collect()
+        Ok(mel.mapv(|x| (x + LOG_ZERO_GUARD).ln()))
     }
 }

--- a/src/parakeet_eou.rs
+++ b/src/parakeet_eou.rs
@@ -2,10 +2,9 @@ use crate::error::{Error, Result};
 use crate::execution::ModelConfig as ExecutionConfig;
 use crate::model_eou::{EncoderCache, ParakeetEOUModel};
 use ndarray::{s, Array2, Array3};
-use realfft::RealFftPlanner;
 use std::collections::VecDeque;
-use std::f32::consts::PI;
 use std::path::Path;
+use std::sync::{Arc, Mutex};
 
 const SAMPLE_RATE: usize = 16000;
 
@@ -17,33 +16,47 @@ const PREEMPH: f32 = 0.97;
 const LOG_ZERO_GUARD: f32 = 5.960_464_5e-8;
 const FMAX: f32 = 8000.0;
 
+/// Shared handle to a loaded ParakeetEOU model.
+/// The ONNX session is loaded once and reference-counted.
+///
+/// Use [`ParakeetEOUHandle::load`] to load from disk, then
+/// [`ParakeetEOU::from_shared`] to spawn each stream with its own decoder state.
+#[derive(Clone)]
+pub struct ParakeetEOUHandle {
+    model: Arc<Mutex<ParakeetEOUModel>>,
+    tokenizer: Arc<tokenizers::Tokenizer>,
+    mel_basis: Arc<Array2<f32>>,
+    blank_id: i32,
+    eou_id: i32,
+}
+
 /// Parakeet RealTime EOU model for streaming ASR with end-of-utterance detection.
 /// Uses cache-aware streaming with audio buffering for pre-encode context.
+///
+/// For a single stream use [`ParakeetEOU::from_pretrained`]. For multiple
+/// concurrent streams sharing one loaded model, use [`ParakeetEOUHandle::load`]
+/// followed by [`ParakeetEOU::from_shared`].
 pub struct ParakeetEOU {
-    model: ParakeetEOUModel,
-    tokenizer: tokenizers::Tokenizer,
+    model: Arc<Mutex<ParakeetEOUModel>>,
+    tokenizer: Arc<tokenizers::Tokenizer>,
+    mel_basis: Arc<Array2<f32>>,
+    blank_id: i32,
+    eou_id: i32,
     encoder_cache: EncoderCache,
     state_h: Array3<f32>,
     state_c: Array3<f32>,
     last_token: Array2<i32>,
-    blank_id: i32,
-    eou_id: i32,
-    mel_basis: Array2<f32>,
-    window: Vec<f32>,
     audio_buffer: VecDeque<f32>,
     buffer_size_samples: usize,
 }
 
-impl ParakeetEOU {
-    /// Load Parakeet EOU model from path
+impl ParakeetEOUHandle {
+    /// Load the ParakeetEOU model, tokenizer, and mel filterbank from a directory.
     ///
-    /// # Arguments
-    /// * `path` - Directory containing encoder.onnx, decoder_joint.onnx, and tokenizer.json
-    /// * `config` - Optional execution configuration (defaults to CPU if None)
-    pub fn from_pretrained<P: AsRef<Path>>(
-        path: P,
-        config: Option<ExecutionConfig>,
-    ) -> Result<Self> {
+    /// Required files:
+    /// - `encoder.onnx`, `decoder_joint.onnx`
+    /// - `tokenizer.json`
+    pub fn load<P: AsRef<Path>>(path: P, config: Option<ExecutionConfig>) -> Result<Self> {
         let path = path.as_ref();
         let tokenizer_path = path.join("tokenizer.json");
         let tokenizer = tokenizers::Tokenizer::from_file(&tokenizer_path)
@@ -59,26 +72,54 @@ impl ParakeetEOU {
 
         let exec_config = config.unwrap_or_default();
         let model = ParakeetEOUModel::from_pretrained(path, exec_config)?;
+        let mel_basis = create_mel_filterbank_htk();
 
+        Ok(Self {
+            model: Arc::new(Mutex::new(model)),
+            tokenizer: Arc::new(tokenizer),
+            mel_basis: Arc::new(mel_basis),
+            blank_id,
+            eou_id,
+        })
+    }
+}
+
+impl ParakeetEOU {
+    /// Load ParakeetEOU from a directory and return a ready-to-use instance.
+    /// Convenience wrapper for the single-stream case.
+    ///
+    /// For multiple concurrent streams sharing one loaded model, use
+    /// [`ParakeetEOUHandle::load`] + [`ParakeetEOU::from_shared`] instead.
+    pub fn from_pretrained<P: AsRef<Path>>(
+        path: P,
+        config: Option<ExecutionConfig>,
+    ) -> Result<Self> {
+        Ok(Self::from_shared(&ParakeetEOUHandle::load(path, config)?))
+    }
+
+    /// Spawn a new ParakeetEOU instance bound to a shared model.
+    ///
+    /// Each instance owns independent encoder cache / decoder state while the
+    /// expensive ONNX session is shared through the handle. The model lock is
+    /// held only during encoder/decoder inference.
+    pub fn from_shared(handle: &ParakeetEOUHandle) -> Self {
         // Buffer size: 4 seconds of audio
         // Provides long history for feature extraction context
         // Note that, I pick those "magic numbers" by looking NeMo's ring buffer approach.
-        let buffer_size_samples = SAMPLE_RATE * 4; // 4 seconds = 64000 samples
-
-        Ok(Self {
-            model,
-            tokenizer,
+        let buffer_size_samples = SAMPLE_RATE * 4;
+        Self {
+            model: Arc::clone(&handle.model),
+            tokenizer: Arc::clone(&handle.tokenizer),
+            mel_basis: Arc::clone(&handle.mel_basis),
+            blank_id: handle.blank_id,
+            eou_id: handle.eou_id,
             encoder_cache: EncoderCache::new(),
             state_h: Array3::zeros((1, 1, 640)),
             state_c: Array3::zeros((1, 1, 640)),
-            last_token: Array2::from_elem((1, 1), blank_id),
-            blank_id,
-            eou_id,
-            mel_basis: Self::create_mel_filterbank(),
-            window: Self::create_window(),
+            last_token: Array2::from_elem((1, 1), handle.blank_id),
             audio_buffer: VecDeque::with_capacity(buffer_size_samples),
             buffer_size_samples,
-        })
+        }
     }
 
     /// Transcribe a chunk of audio samples.
@@ -125,9 +166,13 @@ impl ParakeetEOU {
         let time_steps = features.shape()[2];
 
         // Encode with cache - encoder sees full buffer context
-        let (encoder_out, new_cache) =
-            self.model
-                .run_encoder(&features, time_steps as i64, &self.encoder_cache)?;
+        let (encoder_out, new_cache) = {
+            let mut model = self
+                .model
+                .lock()
+                .map_err(|e| Error::Model(format!("Failed to acquire model lock: {e}")))?;
+            model.run_encoder(&features, time_steps as i64, &self.encoder_cache)?
+        };
         self.encoder_cache = new_cache;
 
         let total_frames = encoder_out.shape()[2];
@@ -140,12 +185,18 @@ impl ParakeetEOU {
 
         let mut text_output = String::new();
 
+        // Hold the lock once across the decoder loop to avoid per-step acquire/release.
+        let mut model = self
+            .model
+            .lock()
+            .map_err(|e| Error::Model(format!("Failed to acquire model lock: {e}")))?;
+
         for t in 0..new_frames.shape()[2] {
             let current_frame = new_frames.slice(s![.., .., t..t + 1]).to_owned();
             let mut syms_added = 0;
 
             while syms_added < 5 {
-                let (logits, new_h, new_c) = self.model.run_decoder(
+                let (logits, new_h, new_c) = model.run_decoder(
                     &current_frame,
                     &self.last_token,
                     &self.state_h,
@@ -169,6 +220,7 @@ impl ParakeetEOU {
 
                 if max_idx == self.eou_id {
                     if reset_on_eou {
+                        drop(model);
                         self.reset_states();
                         return Ok(text_output + " [EOU]");
                     }
@@ -203,112 +255,54 @@ impl ParakeetEOU {
     }
 
     fn extract_mel_features(&self, audio: &[f32]) -> Result<Array3<f32>> {
-        let audio_pre = Self::apply_preemphasis(audio);
-        let spec = self.stft(&audio_pre)?;
+        let audio_pre = crate::audio::apply_preemphasis(audio, PREEMPH);
+        let spec = crate::audio::stft(&audio_pre, N_FFT, HOP_LENGTH, WIN_LENGTH)?;
         let mel = self.mel_basis.dot(&spec);
         let mel_log = mel.mapv(|x| (x.max(0.0) + LOG_ZERO_GUARD).ln());
         Ok(mel_log.insert_axis(ndarray::Axis(0)))
     }
+}
 
-    fn apply_preemphasis(audio: &[f32]) -> Vec<f32> {
-        let mut result = Vec::with_capacity(audio.len());
-        if audio.is_empty() {
-            return result;
+/// HTK mel filterbank used by Parakeet EOU. its distinct from the Slaney-scaled
+/// filterbank in [`crate::audio::create_mel_filterbank`] so please don't confuse :-).
+fn create_mel_filterbank_htk() -> Array2<f32> {
+    let num_freqs = N_FFT / 2 + 1;
+
+    let hz_to_mel = |hz: f32| 2595.0 * (1.0 + hz / 700.0).log10();
+    let mel_to_hz = |mel: f32| 700.0 * (10.0_f32.powf(mel / 2595.0) - 1.0);
+
+    let mel_min = hz_to_mel(0.0);
+    let mel_max = hz_to_mel(FMAX);
+
+    let mel_points: Vec<f32> = (0..=N_MELS + 1)
+        .map(|i| mel_to_hz(mel_min + (mel_max - mel_min) * i as f32 / (N_MELS + 1) as f32))
+        .collect();
+
+    let fft_freqs: Vec<f32> = (0..num_freqs)
+        .map(|i| (SAMPLE_RATE as f32 / N_FFT as f32) * i as f32)
+        .collect();
+
+    let mut weights = Array2::zeros((N_MELS, num_freqs));
+
+    for i in 0..N_MELS {
+        let left = mel_points[i];
+        let center = mel_points[i + 1];
+        let right = mel_points[i + 2];
+        for (j, &freq) in fft_freqs.iter().enumerate() {
+            if freq >= left && freq <= center {
+                weights[[i, j]] = (freq - left) / (center - left);
+            } else if freq > center && freq <= right {
+                weights[[i, j]] = (right - freq) / (right - center);
+            }
         }
-
-        let safe_x = |x: f32| if x.is_finite() { x } else { 0.0 };
-
-        result.push(safe_x(audio[0]));
-        for i in 1..audio.len() {
-            result.push(safe_x(audio[i]) - PREEMPH * safe_x(audio[i - 1]));
-        }
-        result
     }
 
-    fn stft(&self, audio: &[f32]) -> Result<Array2<f32>> {
-        let mut planner = RealFftPlanner::<f32>::new();
-        let r2c = planner.plan_fft_forward(N_FFT);
-
-        let pad_amount = N_FFT / 2;
-        let mut padded_audio = vec![0.0; pad_amount];
-        padded_audio.extend_from_slice(audio);
-        padded_audio.extend(std::iter::repeat_n(0.0, pad_amount));
-
-        let num_frames = 1 + (padded_audio.len().saturating_sub(WIN_LENGTH)) / HOP_LENGTH;
-        let freq_bins = N_FFT / 2 + 1;
-        let mut spec = Array2::zeros((freq_bins, num_frames));
-
-        let mut input = vec![0.0f32; N_FFT];
-        let mut output = r2c.make_output_vec();
-        let mut scratch = r2c.make_scratch_vec();
-
-        for frame_idx in 0..num_frames {
-            let start = frame_idx * HOP_LENGTH;
-            if start + WIN_LENGTH > padded_audio.len() {
-                break;
-            }
-
-            input.fill(0.0);
-            for i in 0..WIN_LENGTH {
-                input[i] = padded_audio[start + i] * self.window[i];
-            }
-
-            r2c.process_with_scratch(&mut input, &mut output, &mut scratch)
-                .map_err(|e| Error::Audio(format!("FFT failed: {e}")))?;
-
-            for (i, val) in output.iter().take(freq_bins).enumerate() {
-                let mag_sq = val.norm_sqr();
-                spec[[i, frame_idx]] = if mag_sq.is_finite() { mag_sq } else { 0.0 };
-            }
+    for i in 0..N_MELS {
+        let enorm = 2.0 / (mel_points[i + 2] - mel_points[i]);
+        for j in 0..num_freqs {
+            weights[[i, j]] *= enorm;
         }
-        Ok(spec)
     }
 
-    fn create_window() -> Vec<f32> {
-        (0..WIN_LENGTH)
-            .map(|i| 0.5 - 0.5 * ((2.0 * PI * i as f32) / ((WIN_LENGTH - 1) as f32)).cos())
-            .collect()
-    }
-
-    fn create_mel_filterbank() -> Array2<f32> {
-        let num_freqs = N_FFT / 2 + 1;
-
-        let hz_to_mel = |hz: f32| 2595.0 * (1.0 + hz / 700.0).log10();
-        let mel_to_hz = |mel: f32| 700.0 * (10.0_f32.powf(mel / 2595.0) - 1.0);
-
-        let mel_min = hz_to_mel(0.0);
-        let mel_max = hz_to_mel(FMAX);
-
-        let mel_points: Vec<f32> = (0..=N_MELS + 1)
-            .map(|i| mel_to_hz(mel_min + (mel_max - mel_min) * i as f32 / (N_MELS + 1) as f32))
-            .collect();
-
-        let fft_freqs: Vec<f32> = (0..num_freqs)
-            .map(|i| (SAMPLE_RATE as f32 / N_FFT as f32) * i as f32)
-            .collect();
-
-        let mut weights = Array2::zeros((N_MELS, num_freqs));
-
-        for i in 0..N_MELS {
-            let left = mel_points[i];
-            let center = mel_points[i + 1];
-            let right = mel_points[i + 2];
-            for (j, &freq) in fft_freqs.iter().enumerate() {
-                if freq >= left && freq <= center {
-                    weights[[i, j]] = (freq - left) / (center - left);
-                } else if freq > center && freq <= right {
-                    weights[[i, j]] = (right - freq) / (right - center);
-                }
-            }
-        }
-
-        for i in 0..N_MELS {
-            let enorm = 2.0 / (mel_points[i + 2] - mel_points[i]);
-            for j in 0..num_freqs {
-                weights[[i, j]] *= enorm;
-            }
-        }
-
-        weights
-    }
+    weights
 }

--- a/src/parakeet_unified.rs
+++ b/src/parakeet_unified.rs
@@ -9,6 +9,7 @@ use crate::timestamps::{process_timestamps, TimestampMode};
 use crate::transcriber::Transcriber;
 use ndarray::Array3;
 use std::path::Path;
+use std::sync::{Arc, Mutex};
 
 const SAMPLE_RATE: usize = 16000;
 const FEATURE_SIZE: usize = 128;
@@ -110,10 +111,23 @@ impl UnifiedStreamingConfig {
     }
 }
 
+/// Shared handle to a loaded ParakeetUnified model.
+/// The ONNX session is loaded once and reference-counted.
+///
+/// Use [`ParakeetUnifiedHandle::load`] to load from disk, then
+/// [`ParakeetUnified::from_shared`] to spawn each stream with its own state.
+#[derive(Clone)]
+pub struct ParakeetUnifiedHandle {
+    model: Arc<Mutex<ParakeetUnifiedModel>>,
+    vocab: Arc<SentencePieceVocab>,
+    preprocessor_config: Arc<PreprocessorConfig>,
+    blank_id: usize,
+}
+
 pub struct ParakeetUnified {
-    model: ParakeetUnifiedModel,
-    vocab: SentencePieceVocab,
-    preprocessor_config: PreprocessorConfig,
+    model: Arc<Mutex<ParakeetUnifiedModel>>,
+    vocab: Arc<SentencePieceVocab>,
+    preprocessor_config: Arc<PreprocessorConfig>,
     state_1: Array3<f32>,
     state_2: Array3<f32>,
     last_token: i32,
@@ -126,26 +140,14 @@ pub struct ParakeetUnified {
     accumulated_timed_tokens: Vec<TimedToken>,
 }
 
-impl ParakeetUnified {
-    pub fn from_pretrained<P: AsRef<Path>>(
+impl ParakeetUnifiedHandle {
+    /// Load the ParakeetUnified model, vocabulary, and preprocessor config
+    /// from a directory.
+    pub fn load<P: AsRef<Path>>(
         path: P,
         exec_config: Option<ExecutionConfig>,
-    ) -> Result<Self> {
-        Self::from_pretrained_with_streaming_config(
-            path,
-            exec_config,
-            UnifiedStreamingConfig::default(),
-        )
-    }
-
-    pub fn from_pretrained_with_streaming_config<P: AsRef<Path>>(
-        path: P,
-        exec_config: Option<ExecutionConfig>,
-        streaming_config: UnifiedStreamingConfig,
     ) -> Result<Self> {
         let path = path.as_ref();
-        let streaming_config = streaming_config.validate()?;
-
         let vocab = SentencePieceVocab::from_file(path.join("tokenizer.model"))?;
         let blank_id = vocab.size();
 
@@ -178,9 +180,57 @@ impl ParakeetUnified {
         };
 
         Ok(Self {
-            model,
-            vocab,
-            preprocessor_config,
+            model: Arc::new(Mutex::new(model)),
+            vocab: Arc::new(vocab),
+            preprocessor_config: Arc::new(preprocessor_config),
+            blank_id,
+        })
+    }
+}
+
+impl ParakeetUnified {
+    pub fn from_pretrained<P: AsRef<Path>>(
+        path: P,
+        exec_config: Option<ExecutionConfig>,
+    ) -> Result<Self> {
+        Self::from_pretrained_with_streaming_config(
+            path,
+            exec_config,
+            UnifiedStreamingConfig::default(),
+        )
+    }
+
+    pub fn from_pretrained_with_streaming_config<P: AsRef<Path>>(
+        path: P,
+        exec_config: Option<ExecutionConfig>,
+        streaming_config: UnifiedStreamingConfig,
+    ) -> Result<Self> {
+        let handle = ParakeetUnifiedHandle::load(path, exec_config)?;
+        Self::from_shared_with_streaming_config(&handle, streaming_config)
+    }
+
+    /// Spawn a new ParakeetUnified instance bound to a shared model, using the
+    /// default streaming profile.
+    pub fn from_shared(handle: &ParakeetUnifiedHandle) -> Self {
+        // default config is pre-validated, so unwrap is safe
+        Self::from_shared_with_streaming_config(handle, UnifiedStreamingConfig::default())
+            .expect("default UnifiedStreamingConfig is always valid")
+    }
+
+    /// Spawn a new ParakeetUnified instance bound to a shared model with a
+    /// custom streaming profile. Each instance owns independent decoder and
+    /// audio-buffer state; the ONNX session is shared through the handle.
+    pub fn from_shared_with_streaming_config(
+        handle: &ParakeetUnifiedHandle,
+        streaming_config: UnifiedStreamingConfig,
+    ) -> Result<Self> {
+        let streaming_config = streaming_config.validate()?;
+        let blank_id = handle.blank_id;
+
+        Ok(Self {
+            model: Arc::clone(&handle.model),
+            vocab: Arc::clone(&handle.vocab),
+            preprocessor_config: Arc::clone(&handle.preprocessor_config),
             state_1: Array3::zeros((DECODER_LSTM_LAYERS, 1, DECODER_LSTM_DIM)),
             state_2: Array3::zeros((DECODER_LSTM_LAYERS, 1, DECODER_LSTM_DIM)),
             last_token: blank_id as i32,
@@ -283,7 +333,12 @@ impl ParakeetUnified {
                 1,
                 &self.preprocessor_config,
             )?;
-            let (encoded, encoded_len) = self.model.run_encoder(&features)?;
+            let (encoded, encoded_len) = {
+                let mut model = self.model.lock().map_err(|e| {
+                    Error::Model(format!("Failed to acquire model lock: {e}"))
+                })?;
+                model.run_encoder(&features)?
+            };
 
             let available_frames = (encoded_len as usize).min(encoded.shape()[2]);
             let start_frame = left_encoder_frames.min(available_frames);
@@ -388,6 +443,12 @@ impl ParakeetUnified {
         let hidden_dim = encoder_out.shape()[1];
         let end_frame = end_frame.min(encoder_out.shape()[2]);
 
+        // Hold the lock once across the decoder loop to avoid per-step acquire/release.
+        let mut model = self
+            .model
+            .lock()
+            .map_err(|e| Error::Model(format!("Failed to acquire model lock: {e}")))?;
+
         for frame_idx in start_frame..end_frame {
             let frame = encoder_out
                 .slice(ndarray::s![0, .., frame_idx])
@@ -399,7 +460,7 @@ impl ParakeetUnified {
             let absolute_frame = absolute_frame_offset + (frame_idx - start_frame);
 
             for _ in 0..MAX_SYMBOLS_PER_STEP {
-                let (logits, new_state_1, new_state_2) = self.model.run_decoder(
+                let (logits, new_state_1, new_state_2) = model.run_decoder(
                     &frame,
                     self.last_token,
                     &self.state_1,
@@ -463,7 +524,13 @@ impl ParakeetUnified {
         self.reset();
 
         let features = audio::extract_features_raw(audio, sample_rate, channels, &self.preprocessor_config)?;
-        let (encoded, encoded_len) = self.model.run_encoder(&features)?;
+        let (encoded, encoded_len) = {
+            let mut model = self
+                .model
+                .lock()
+                .map_err(|e| Error::Model(format!("Failed to acquire model lock: {e}")))?;
+            model.run_encoder(&features)?
+        };
         let frame_count = (encoded_len as usize).min(encoded.shape()[2]);
         let tokens = self.decode_encoder_frames(&encoded, 0, frame_count, 0)?;
         self.accumulated_tokens = tokens.iter().map(|(id, _)| *id).collect();


### PR DESCRIPTION
Following up on @kgentic-dev's NemotronHandle idea applies the same opaque handle pattern to ParakeetEOU and ParakeetUnified, which have the same session + per-stream state coupling. Also consolidates duplicated preemphasis and STFT helpers into crate::audio, and extends examples/shared_model.rs with [eou|unified] CLI variants. Transcripts byte identical to on both models; ~28% RSS and ~49% peak-footprint savings with two shared instances vs two independent loads...