### PR TITLE
[Cohere] add runnable example, drop preprocessor config.json dep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ DS_Store
 *.wav
 *.txt
 *.onnx.data
+*.onnx_data_*
 *.model

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "parakeet-rs"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "eyre",
  "hound",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parakeet-rs"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 authors = ["altunenes"]
 description = "Fast ASR & Speaker Diarization with NVIDIA Parakeet via ONNX"
@@ -36,6 +36,11 @@ path = "examples/streaming_diarization.rs"
 [[example]]
 name = "shared_model"
 path = "examples/shared_model.rs"
+
+[[example]]
+name = "cohere"
+path = "examples/cohere.rs"
+required-features = ["cohere"]
 
 [dependencies]
 ort = { version = "2.0.0-rc.12", default-features = false, features = ["std", "ndarray", "api-24"] }

--- a/README.md
+++ b/README.md
@@ -69,6 +69,21 @@ for chunk in audio.chunks(CHUNK_SIZE) {
 }
 ```
 
+**Cohere Transcribe (Offline Multilingual)**: 14 languages, punctuation & ITN toggles (yes, "parakeets🦜" talk about more than just NVIDIA right?? :-P)
+```toml
+parakeet-rs = { version = "0.3", features = ["cohere"] }
+```
+```rust
+use parakeet_rs::CohereASR;
+
+let mut model = CohereASR::from_pretrained("./cohere", None)?;
+
+// audio: Vec<f32>, 16kHz mono (long-form supported)
+let text = model.transcribe_audio(&audio, "en", true, false)?; // lang, pnc, itn
+println!("{}", text);
+```
+See `examples/cohere.rs` for a runnable demo.
+
 **Multitalker (Streaming Multi-Speaker ASR)**: Speaker-attributed transcription
 ```toml
 parakeet-rs = { version = "0.3", features = ["multitalker"] }
@@ -132,6 +147,8 @@ See `scripts/export_diar_sortformer.py` for exporting the model with custom stre
 
 **Multitalker**: Download from [HuggingFace](https://huggingface.co/smcleod/multitalker-parakeet-streaming-0.6b-v1-onnx-int8/tree/main): `encoder.int8.onnx`, `decoder_joint.int8.onnx`, `tokenizer.model` (also needs a Sortformer model for diarization)
 
+**Cohere Transcribe**: Download from [HuggingFace](https://huggingface.co/onnx-community/cohere-transcribe-03-2026-ONNX): `encoder_model.onnx` (+ `.onnx_data*`), `decoder_model_merged.onnx` (+ `.onnx_data`), `tokenizer.json` (FP32, FP16, INT8, INT4 variants available)
+
 **Diarization (Sortformer v2 & v2.1)**: Download from [HuggingFace](https://huggingface.co/altunenes/parakeet-rs/tree/main): `diar_streaming_sortformer_4spk-v2.onnx` or `v2.1.onnx`.
 
 Quantized versions available (int8). All files must be in the same directory.
@@ -162,6 +179,7 @@ let config = ExecutionConfig::new()
 - [Nemotron: Cache aware streaming ASR (600M params,EN only)](https://huggingface.co/nvidia/nemotron-speech-streaming-en-0.6b)
 - [Unified: Offline + buffered streaming RNNT ASR (600M params, EN only)](https://huggingface.co/nvidia/parakeet-unified-en-0.6b)
 - [Multitalker: Streaming multi-speaker ASR with speaker-kernel injection](https://huggingface.co/nvidia/multitalker-parakeet-streaming-0.6b-v1) ([ONNX int8](https://huggingface.co/smcleod/multitalker-parakeet-streaming-0.6b-v1-onnx-int8))
+- [Cohere Transcribe: Offline multilingual ASR (14 languages, long-form supported)](https://huggingface.co/CohereLabs/cohere-transcribe-03-2026) ([ONNX](https://huggingface.co/onnx-community/cohere-transcribe-03-2026-ONNX))
 - [Sortformer v2 & v2.1: Streaming speaker diarization (up to 4 speakers)](https://huggingface.co/nvidia/diar_streaming_sortformer_4spk-v2) NOTE: you can also download v2.1 model same way.
 - Token-level timestamps (CTC, TDT)
 

--- a/examples/cohere.rs
+++ b/examples/cohere.rs
@@ -1,0 +1,92 @@
+/*
+Cohere Transcribe ASR — offline multilingual transcription.
+
+2B parameter encoder-decoder model supporting 14 languages with inverse text norm.
+Max audio duration is ~35s (the training range); chunk longer recordings.
+
+Download the ONNX export from:
+https://huggingface.co/onnx-community/cohere-transcribe-03-2026-ONNX
+
+Usage:
+  cargo run --release --example cohere --features cohere -- \
+    <model_dir> <audio.wav> [lang] [pnc] [itn]
+
+Examples:
+  cargo run --release --example cohere --features cohere -- ./cohere audio.wav
+  cargo run --release --example cohere --features cohere -- ./cohere audio.wav en true false
+  cargo run --release --example cohere --features cohere -- ./cohere audio.wav ja true true
+
+Languages: ar, de, el, en, es, fr, it, ja, ko, nl, pl, pt, vi, zh
+*/
+
+#[cfg(feature = "cohere")]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use parakeet_rs::CohereASR;
+    use std::env;
+    use std::time::Instant;
+
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 3 {
+        eprintln!(
+            "Usage: {} <model_dir> <audio.wav> [lang] [pnc] [itn]",
+            args[0]
+        );
+        std::process::exit(1);
+    }
+
+    let model_dir = &args[1];
+    let audio_path = &args[2];
+    let language = args.get(3).map(String::as_str).unwrap_or("en");
+    let pnc = args.get(4).map(|s| s == "true").unwrap_or(true);
+    let itn = args.get(5).map(|s| s == "true").unwrap_or(false);
+
+    let mut reader = hound::WavReader::open(audio_path)?;
+    let spec = reader.spec();
+    if spec.sample_rate != 16000 {
+        return Err(format!("Expected 16kHz audio, got {}Hz", spec.sample_rate).into());
+    }
+
+    let mut audio: Vec<f32> = match spec.sample_format {
+        hound::SampleFormat::Float => reader.samples::<f32>().collect::<Result<Vec<_>, _>>()?,
+        hound::SampleFormat::Int => reader
+            .samples::<i16>()
+            .map(|s| s.map(|v| v as f32 / 32768.0))
+            .collect::<Result<Vec<_>, _>>()?,
+    };
+    if spec.channels > 1 {
+        audio = audio
+            .chunks(spec.channels as usize)
+            .map(|c| c.iter().sum::<f32>() / spec.channels as f32)
+            .collect();
+    }
+
+    let duration_secs = audio.len() as f32 / 16000.0;
+    println!(
+        "Audio: {:.2}s, language={}, pnc={}, itn={}",
+        duration_secs, language, pnc, itn
+    );
+
+    println!("Loading Cohere model...");
+    let load_start = Instant::now();
+    let mut model = CohereASR::from_pretrained(model_dir, None)?;
+    println!("Loaded in {:.2}s", load_start.elapsed().as_secs_f32());
+
+    let start = Instant::now();
+    let text = model.transcribe_audio(&audio, language, pnc, itn)?;
+    let elapsed = start.elapsed().as_secs_f32();
+
+    println!("\n{}", text);
+    println!(
+        "\nTranscribed in {:.2}s (RTF {:.2}x)",
+        elapsed,
+        duration_secs / elapsed
+    );
+
+    Ok(())
+}
+
+#[cfg(not(feature = "cohere"))]
+fn main() {
+    eprintln!("Rebuild with --features cohere to run this example.");
+    std::process::exit(1);
+}

--- a/src/cohere.rs
+++ b/src/cohere.rs
@@ -69,12 +69,12 @@ const MAX_DECODE_TOKENS_LIMIT: usize = 1024;
 /// covers the training range (`max_audio_clip_s = 35`).
 const DEFAULT_MAX_DECODE_TOKENS: usize = 512;
 
-/// Maximum audio duration the model was trained on, as recorded in
-/// `preprocessor_config.json` (`max_audio_clip_s`). Audio longer than this
-/// will still run but transcription quality degrades beyond the training
-/// range. Exposed via [`CohereASR::max_audio_duration_secs`] for callers
-/// that want to chunk long audio.
-const MAX_AUDIO_DURATION_SECS: f32 = 35.0;
+/// Training chunk length recorded in `preprocessor_config.json`
+/// (`max_audio_clip_s`). This is *not* a runtime limit — the official model
+/// card lists long-form transcription as a supported feature and audio well
+/// past this length transcribes fine. Exposed via
+/// [`CohereASR::training_chunk_secs`] only as informational metadata :-)
+const TRAINING_CHUNK_SECS: f32 = 35.0;
 
 // The 14 languages officially supported by Cohere Transcribe
 // (cohere-transcribe-03-2026). The tokenizer contains `<|xx|>` placeholders
@@ -84,27 +84,68 @@ const SUPPORTED_LANGUAGES: &[&str] = &[
     "ar", "de", "el", "en", "es", "fr", "it", "ja", "ko", "nl", "pl", "pt", "vi", "zh",
 ];
 
+
+struct DecoderTokens {
+    decoder_start: i64,
+    startofcontext: i64,
+    sot: i64,
+    emo_undefined: i64,
+    eos: i64,
+    pnc: i64,
+    nopnc: i64,
+    notimestamp: i64,
+    nodiarize: i64,
+    itn: i64,
+    noitn: i64,
+}
+
+impl DecoderTokens {
+    fn resolve(tokenizer: &Tokenizer) -> Result<Self> {
+        Ok(Self {
+            decoder_start: require_token(tokenizer, TOKEN_WORD_BOUNDARY)?,
+            startofcontext: require_token(tokenizer, TOKEN_STARTOFCONTEXT)?,
+            sot: require_token(tokenizer, TOKEN_STARTOFTRANSCRIPT)?,
+            emo_undefined: require_token(tokenizer, TOKEN_EMO_UNDEFINED)?,
+            eos: require_token(tokenizer, TOKEN_ENDOFTEXT)?,
+            pnc: require_token(tokenizer, TOKEN_PNC)?,
+            nopnc: require_token(tokenizer, TOKEN_NOPNC)?,
+            notimestamp: require_token(tokenizer, TOKEN_NOTIMESTAMP)?,
+            nodiarize: require_token(tokenizer, TOKEN_NODIARIZE)?,
+            itn: require_token(tokenizer, TOKEN_ITN)?,
+            noitn: require_token(tokenizer, TOKEN_NOITN)?,
+        })
+    }
+}
+
+/// Values on here are mirror from `preprocessor_config.json` in the upstream HF export. they are baked
+/// into the encoder's ONNX graph (feature_size=128, hop=160, etc.) and
+/// are not user tunable, so we hardcode them rather than requiring the
+/// file on disk. If they share onnx script, we could consider something just like we did for the sorftformer.
+fn cohere_preprocessor_config() -> PreprocessorConfig {
+    PreprocessorConfig {
+        feature_extractor_type: "CohereAsrFeatureExtractor".to_string(),
+        feature_size: N_MELS,
+        hop_length: 160,
+        n_fft: 512,
+        padding_side: "right".to_string(),
+        padding_value: 0.0,
+        preemphasis: 0.97,
+        processor_class: "CohereAsrProcessor".to_string(),
+        return_attention_mask: true,
+        sampling_rate: 16000,
+        win_length: 400,
+    }
+}
+
 /// Cohere Transcribe ASR engine.
 pub struct CohereASR {
     model: CohereModel,
     tokenizer: Tokenizer,
-    /// Mel/STFT parameters loaded from `preprocessor_config.json`.
+    /// Mel/STFT parameters (hardcoded — see [`cohere_preprocessor_config`]).
     preprocessor: PreprocessorConfig,
     /// Map of supported ISO 639-1 language code -> language token id.
     lang_tokens: HashMap<String, i64>,
-    /// Cached prompt token ids: startoftranscript / endoftext / pnc / nopnc /
-    /// notimestamp / itn / noitn.
-    decoder_start_id: i64,
-    startofcontext_id: i64,
-    sot_id: i64,
-    emo_undefined_id: i64,
-    eos_id: i64,
-    pnc_id: i64,
-    nopnc_id: i64,
-    notimestamp_id: i64,
-    nodiarize_id: i64,
-    itn_id: i64,
-    noitn_id: i64,
+    tokens: DecoderTokens,
     /// Maximum number of tokens to generate per `transcribe_audio` call.
     /// Defaults to [`DEFAULT_MAX_DECODE_TOKENS`] (512). Capped at
     /// [`MAX_DECODE_TOKENS_LIMIT`] (1024).
@@ -118,7 +159,8 @@ impl CohereASR {
     /// - one of `encoder_model[_quantized|_fp16].onnx` (+ `.onnx_data` companions)
     /// - one of `decoder_model_merged[_quantized|_fp16].onnx` (+ `.onnx_data`)
     /// - `tokenizer.json`
-    /// - `preprocessor_config.json`
+    ///
+    /// parameters are hardcoded since they are fixed by the encoder graph.
     ///
     /// This layout matches the [`onnx-community/cohere-transcribe-03-2026-ONNX`](https://huggingface.co/onnx-community/cohere-transcribe-03-2026-ONNX)
     /// HF repository.
@@ -141,37 +183,8 @@ impl CohereASR {
         let tokenizer = Tokenizer::from_file(&tokenizer_path)
             .map_err(|e| Error::Tokenizer(format!("Failed to load tokenizer.json: {e}")))?;
 
-        let preprocessor_path = model_dir.join("preprocessor_config.json");
-        if !preprocessor_path.exists() {
-            return Err(Error::Config(format!(
-                "Missing preprocessor_config.json in {}",
-                model_dir.display()
-            )));
-        }
-        let preprocessor: PreprocessorConfig =
-            serde_json::from_str(&std::fs::read_to_string(&preprocessor_path).map_err(|e| {
-                Error::Config(format!("Failed to read preprocessor_config.json: {e}"))
-            })?)
-            .map_err(|e| Error::Config(format!("Failed to parse preprocessor_config.json: {e}")))?;
-
-        if preprocessor.feature_size != N_MELS {
-            return Err(Error::Config(format!(
-                "Cohere Transcribe expects feature_size=128, got {}",
-                preprocessor.feature_size
-            )));
-        }
-
-        let decoder_start_id = require_token(&tokenizer, TOKEN_WORD_BOUNDARY)?;
-        let startofcontext_id = require_token(&tokenizer, TOKEN_STARTOFCONTEXT)?;
-        let sot_id = require_token(&tokenizer, TOKEN_STARTOFTRANSCRIPT)?;
-        let emo_undefined_id = require_token(&tokenizer, TOKEN_EMO_UNDEFINED)?;
-        let eos_id = require_token(&tokenizer, TOKEN_ENDOFTEXT)?;
-        let pnc_id = require_token(&tokenizer, TOKEN_PNC)?;
-        let nopnc_id = require_token(&tokenizer, TOKEN_NOPNC)?;
-        let notimestamp_id = require_token(&tokenizer, TOKEN_NOTIMESTAMP)?;
-        let nodiarize_id = require_token(&tokenizer, TOKEN_NODIARIZE)?;
-        let itn_id = require_token(&tokenizer, TOKEN_ITN)?;
-        let noitn_id = require_token(&tokenizer, TOKEN_NOITN)?;
+        let preprocessor = cohere_preprocessor_config();
+        let tokens = DecoderTokens::resolve(&tokenizer)?;
 
         let mut lang_tokens = HashMap::with_capacity(SUPPORTED_LANGUAGES.len());
         for code in SUPPORTED_LANGUAGES {
@@ -191,27 +204,17 @@ impl CohereASR {
             tokenizer,
             preprocessor,
             lang_tokens,
-            decoder_start_id,
-            startofcontext_id,
-            sot_id,
-            emo_undefined_id,
-            eos_id,
-            pnc_id,
-            nopnc_id,
-            notimestamp_id,
-            nodiarize_id,
-            itn_id,
-            noitn_id,
+            tokens,
             max_decode_tokens: DEFAULT_MAX_DECODE_TOKENS,
         })
     }
 
-    /// Maximum audio duration (in seconds) the model was trained on.
-    /// Audio longer than this will still be transcribed but quality
-    /// degrades outside the training range. Callers that process long
-    /// recordings should chunk into segments of this length or shorter.
-    pub fn max_audio_duration_secs(&self) -> f32 {
-        MAX_AUDIO_DURATION_SECS
+    /// Training chunk length (in seconds) recorded in the upstream
+    /// `preprocessor_config.json`. Exposed as metadata only — the model
+    /// card lists long-form transcription as supported and audio longer
+    /// than this transcribes fine in practice.
+    pub fn training_chunk_secs(&self) -> f32 {
+        TRAINING_CHUNK_SECS
     }
 
     /// Current maximum number of tokens the decoder will emit per call.
@@ -273,23 +276,20 @@ impl CohereASR {
         //    CohereAsrProcessor in transformers produces. The source and
         //    target language tokens are both the caller's `language` code
         //    since this is pure transcription (no translation).
-        let pnc_token = if punctuation {
-            self.pnc_id
-        } else {
-            self.nopnc_id
-        };
-        let itn_token = if itn { self.itn_id } else { self.noitn_id };
+        let t = &self.tokens;
+        let pnc_token = if punctuation { t.pnc } else { t.nopnc };
+        let itn_token = if itn { t.itn } else { t.noitn };
         let prompt = vec![
-            self.decoder_start_id,
-            self.startofcontext_id,
-            self.sot_id,
-            self.emo_undefined_id,
+            t.decoder_start,
+            t.startofcontext,
+            t.sot,
+            t.emo_undefined,
             lang_token,
             lang_token,
             pnc_token,
             itn_token,
-            self.notimestamp_id,
-            self.nodiarize_id,
+            t.notimestamp,
+            t.nodiarize,
         ];
 
         // 4. Greedy decode loop
@@ -336,7 +336,7 @@ impl CohereASR {
         past_kv = new_past;
 
         let mut next_token = argmax(logits.as_slice().unwrap());
-        if next_token == self.eos_id {
+        if next_token == self.tokens.eos {
             return Ok(output_tokens);
         }
         output_tokens.push(next_token);
@@ -351,7 +351,7 @@ impl CohereASR {
             past_kv = new_past;
 
             next_token = argmax(logits.as_slice().unwrap());
-            if next_token == self.eos_id {
+            if next_token == self.tokens.eos {
                 break;
             }
             output_tokens.push(next_token);


### PR DESCRIPTION
Adds a runnable examples/cohere.rs (feature-gated), removes the preprocessor_config.json file dependency (values are fixed by the encoder graph,now hardcoded), and groups the 11 decoder-prompt token ids into a DecoderTokens substruct...

