### PR TITLE
add ai contributing policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+## Reporting bugs
+
+Open an issue with enough detail to reproduce it:
+
+- your OS, GPU, and EP
+- which example and the steps to trigger it
+- what you expected vs. what happened etc
+
+## Changes and features
+
+For small things or bug fixes that you can reproduce just open a pull request. For larger arch changes or features, it helps to open an issue first describing what you're trying to achieve could be really helpful to discuss together :-)
+
+## AI / LLM contribution policy
+
+> This policy is adapted from [GTK's AI contribution policy](https://gitlab.gnome.org/GNOME/gtk/-/blob/main/CONTRIBUTING.md#ai-contribution-policy), which inspired most of the thinking here. 
+
+- **You own it.** If you used an AI tool, you are still 100% responsible for the
+  change. "The AI wrote it","AI suggested it", "AI verified it" is never an explanation, and never a defense.
+- **Understand and test what you submit.** Run it. Verify it does what you
+  claim. Do not open a PR for code, docs, or tests you can't explain yourself.
+- **Don't fabricate.** No invented benchmarks, test results, bug reports, or
+  reproducers.
+- **Respect licensing and attribution.** Don't launder someone else's work
+  through a model; credit what you build on. 
+- **Disclose AI use in the PR description** if you used an AI, a sentence on what you used and
+  how you verified it. Please don't add `Co-authored-by:` / `Assisted-by:`
+  trailers to commits; the responsibility is yours to state in your own words,
+  not a llm to advertise.
+
+If you can stand behind it and explain it, it's welcome here. That's the whole bar and it's the same bar a human writing every line by hand would meet.


### PR DESCRIPTION
The AI section is adapted from GTK's AI contribution policy, which I borrowed most of the thinking from :

https://gitlab.gnome.org/GNOME/gtk/-/blob/main/CONTRIBUTING.md#ai-contribution-policy

happy to refine the wording, scope, or tone based on feedback.  🙂