### PR TITLE
fix: use TDT durations for timestamps

### DIFF
--- a/src/audio.rs
+++ b/src/audio.rs
@@ -97,9 +97,14 @@ pub fn stft_with_plan(
     padded.resize(padded.len() + pad_amount, 0.0);
 
     let window = hann_window(win_length);
-    let num_frames = (padded.len() - n_fft) / hop_length + 1;
+    // NeMo reports floor(audio_len / hop_length) valid frames. torch.stft
+    // produces one additional trailing frame, which NeMo masks out before
+    // normalization and encoding.
+    let num_frames = audio.len() / hop_length;
     let freq_bins = n_fft / 2 + 1;
     let mut spectrogram = Array2::<f32>::zeros((freq_bins, num_frames));
+    // torch.stft centers a window shorter than n_fft in the FFT buffer.
+    let window_offset = (n_fft - win_length) / 2;
 
     let mut input = vec![0.0f32; n_fft];
     let mut output = plan.make_output_vec();
@@ -109,8 +114,8 @@ pub fn stft_with_plan(
         let start = frame_idx * hop_length;
 
         input.fill(0.0);
-        for i in 0..win_length.min(padded.len() - start) {
-            input[i] = padded[start + i] * window[i];
+        for i in 0..win_length {
+            input[window_offset + i] = padded[start + window_offset + i] * window[i];
         }
 
         plan.process_with_scratch(&mut input, &mut output, &mut scratch)
@@ -326,7 +331,6 @@ mod tests {
 
         let freq_bins = n_fft / 2 + 1;
         assert_eq!(spec.shape()[0], freq_bins);
-        // num_frames = (audio_len + n_fft - n_fft) / hop_length + 1 = 16000 / 160 + 1 = 101
-        assert!(spec.shape()[1] > 0);
+        assert_eq!(spec.shape()[1], audio.len() / hop_length);
     }
 }

--- a/src/decoder_tdt.rs
+++ b/src/decoder_tdt.rs
@@ -20,7 +20,7 @@ impl ParakeetTDTDecoder {
         &self,
         tokens: &[usize],
         frame_indices: &[usize],
-        _durations: &[usize],
+        durations: &[usize],
         hop_length: usize,
         sample_rate: usize,
     ) -> Result<TranscriptionResult> {
@@ -33,11 +33,8 @@ impl ParakeetTDTDecoder {
             if let Some(token_text) = self.vocab.id_to_text(token_id) {
                 let frame = frame_indices[i];
                 let start = (frame * encoder_stride * hop_length) as f32 / sample_rate as f32;
-                let end = if i + 1 < frame_indices.len() {
-                    (frame_indices[i + 1] * encoder_stride * hop_length) as f32 / sample_rate as f32
-                } else {
-                    start + 0.01
-                };
+                let end_frame = frame + durations[i];
+                let end = (end_frame * encoder_stride * hop_length) as f32 / sample_rate as f32;
 
                 // Handle SentencePiece format (▁ prefix for word start)
                 let mut display_text = token_text.replace('▁', " ");
@@ -200,5 +197,20 @@ mod tests {
         // Test Tokens mode
         let tokens_text: String = result.tokens.iter().map(|t| t.text.as_str()).collect();
         assert_eq!(tokens_text.trim(), "like 100 bucks");
+    }
+
+    #[test]
+    fn test_timestamps_use_predicted_durations() {
+        let vocab = make_vocab(&["▁one", "▁two", "▁three"]);
+        let decoder = ParakeetTDTDecoder::from_vocab(vocab);
+        let result = decoder
+            .decode_with_timestamps(&[0, 1, 2], &[10, 20, 22], &[3, 0, 4], 160, 16000)
+            .unwrap();
+
+        let expected = [(0.8, 1.04), (1.6, 1.6), (1.76, 2.08)];
+        for (token, (expected_start, expected_end)) in result.tokens.iter().zip(expected) {
+            assert!((token.start - expected_start).abs() < f32::EPSILON);
+            assert!((token.end - expected_end).abs() < f32::EPSILON);
+        }
     }
 }

--- a/src/decoder_tdt.rs
+++ b/src/decoder_tdt.rs
@@ -198,19 +198,4 @@ mod tests {
         let tokens_text: String = result.tokens.iter().map(|t| t.text.as_str()).collect();
         assert_eq!(tokens_text.trim(), "like 100 bucks");
     }
-
-    #[test]
-    fn test_timestamps_use_predicted_durations() {
-        let vocab = make_vocab(&["▁one", "▁two", "▁three"]);
-        let decoder = ParakeetTDTDecoder::from_vocab(vocab);
-        let result = decoder
-            .decode_with_timestamps(&[0, 1, 2], &[10, 20, 22], &[3, 0, 4], 160, 16000)
-            .unwrap();
-
-        let expected = [(0.8, 1.04), (1.6, 1.6), (1.76, 2.08)];
-        for (token, (expected_start, expected_end)) in result.tokens.iter().zip(expected) {
-            assert!((token.start - expected_start).abs() < f32::EPSILON);
-            assert!((token.end - expected_end).abs() < f32::EPSILON);
-        }
-    }
 }


### PR DESCRIPTION
Any reason why durations aren't used here? The transcriptions are slightly more accurate for me, but it seems like they were purposefully excluded.