### PR TITLE
Make ModelConfig::build_session public

### DIFF
--- a/src/execution.rs
+++ b/src/execution.rs
@@ -133,7 +133,8 @@ impl ModelConfig {
         self.coreml_compute_units = units;
         self
     }
-    pub(crate) fn build_session(&self, path: &Path) -> Result<Session> {
+    /// Build a session for `path` under this configuration.
+    pub fn build_session(&self, path: &Path) -> Result<Session> {
         let builder = Session::builder()?;
         let mut builder = self.apply_to_session_builder(builder)?;
         Ok(builder.commit_from_file(path)?)


### PR DESCRIPTION
Right now a session can only be built from a `ModelConfig` inside the crate. Both
`build_session` and `apply_to_session_builder` are `pub(crate)`.

If I want a second session under the same configuration — another graph, or one built later
instead of at load time — I have to go to `ort` directly and write again what this method
already does.

The method exists and is already used inside the crate. This only makes it public.

AI note: I used an AI assistant for this change. I read it and verified it with
`cargo check --features sortformer`.
