### PR TITLE
Make ModelConfig Send + Sync

### DIFF
--- a/src/execution.rs
+++ b/src/execution.rs
@@ -1,5 +1,5 @@
 use std::path::{Path, PathBuf};
-use std::{fmt, rc::Rc};
+use std::{fmt, sync::Arc};
 
 use crate::error::Result;
 use ort::session::builder::SessionBuilder;
@@ -51,7 +51,7 @@ pub struct ModelConfig {
     pub execution_provider: ExecutionProvider,
     pub intra_threads: usize,
     pub inter_threads: usize,
-    pub configure: Option<Rc<dyn Fn(SessionBuilder) -> ort::Result<SessionBuilder>>>,
+    pub configure: Option<Arc<dyn Fn(SessionBuilder) -> ort::Result<SessionBuilder> + Send + Sync>>,
     /// Optional cache directory for compiled CoreML models. When set, avoids
     /// recompiling the ONNX-to-CoreML conversion on each session load (~5s).
     /// Only used when execution_provider is CoreML.
@@ -114,9 +114,9 @@ impl ModelConfig {
 
     pub fn with_custom_configure(
         mut self,
-        configure: impl Fn(SessionBuilder) -> ort::Result<SessionBuilder> + 'static,
+        configure: impl Fn(SessionBuilder) -> ort::Result<SessionBuilder> + Send + Sync + 'static,
     ) -> Self {
-        self.configure = Some(Rc::new(configure));
+        self.configure = Some(Arc::new(configure));
         self
     }
 


### PR DESCRIPTION
The custom configure hook is held in an `Rc`, so `ModelConfig` is neither `Send` nor `Sync`,
and neither is anything that stores one.

That becomes a problem as soon as the config has to outlive the call that built the session.
Keeping a config around to rebuild a session later, or holding a model behind a mutex in an
async runtime, both stop compiling — for a reason that has nothing to do with the callback.

This changes `Rc` to `Arc` and adds `Send + Sync` to the closure bound. Behaviour is the same;
the closure is only ever called while a session is being built.

AI note: I used an AI assistant for this change. I read it and verified it with
`cargo check --features sortformer`.
