### PR TITLE
Allow a separate execution config for the TDT decoder/joint

### DIFF
--- a/src/model_tdt.rs
+++ b/src/model_tdt.rs
@@ -35,6 +35,24 @@ impl ParakeetTDTModel {
         exec_config: ExecutionConfig,
         vocab_size: usize,
     ) -> Result<Self> {
+        let joint_config = exec_config.clone();
+        Self::from_pretrained_with_configs(model_dir, exec_config, joint_config, vocab_size)
+    }
+
+    /// Load a TDT model, running the encoder and the decoder/joint under separate execution
+    /// configurations.
+    ///
+    /// # Arguments
+    /// * `model_dir` - Directory containing encoder and decoder_joint ONNX files
+    /// * `exec_config` - Execution configuration for the encoder session
+    /// * `joint_config` - Execution configuration for the decoder/joint session
+    /// * `vocab_size` - Vocabulary size (number of tokens including blank)
+    pub fn from_pretrained_with_configs<P: AsRef<Path>>(
+        model_dir: P,
+        exec_config: ExecutionConfig,
+        joint_config: ExecutionConfig,
+        vocab_size: usize,
+    ) -> Result<Self> {
         let model_dir = model_dir.as_ref();
 
         // Find encoder and decoder_joint files
@@ -44,7 +62,7 @@ impl ParakeetTDTModel {
         let config = TDTModelConfig::new(vocab_size);
 
         let encoder = exec_config.build_session(&encoder_path)?;
-        let decoder_joint = exec_config.build_session(&decoder_joint_path)?;
+        let decoder_joint = joint_config.build_session(&decoder_joint_path)?;
 
         Ok(Self {
             encoder,

--- a/src/parakeet_tdt.rs
+++ b/src/parakeet_tdt.rs
@@ -29,6 +29,27 @@ impl ParakeetTDT {
         path: P,
         config: Option<ExecutionConfig>,
     ) -> Result<Self> {
+        let joint_config = config.clone();
+        Self::from_pretrained_with_joint_config(path, config, joint_config)
+    }
+
+    /// Load Parakeet TDT model from path, running the decoder/joint graph under its own execution
+    /// configuration.
+    ///
+    /// The encoder and the decoder/joint are separate ONNX graphs and do not have to run on the
+    /// same execution provider. Splitting them matters when a provider can take one graph and not
+    /// the other, and the joint runs once per token, so where it runs is a decision of its own.
+    ///
+    /// # Arguments
+    /// * `path` - Directory containing encoder-model.onnx, decoder_joint-model.onnx, and vocab.txt
+    /// * `config` - Optional execution configuration for the encoder (defaults to CPU if None)
+    /// * `joint_config` - Optional execution configuration for the decoder/joint (defaults to CPU
+    ///   if None)
+    pub fn from_pretrained_with_joint_config<P: AsRef<Path>>(
+        path: P,
+        config: Option<ExecutionConfig>,
+        joint_config: Option<ExecutionConfig>,
+    ) -> Result<Self> {
         let path = path.as_ref();
 
         if !path.is_dir() {
@@ -62,12 +83,18 @@ impl ParakeetTDT {
         };
 
         let exec_config = config.unwrap_or_default();
+        let joint_exec_config = joint_config.unwrap_or_default();
 
         // Load vocab first to get the actual vocabulary size
         let vocab = Vocabulary::from_file(&vocab_path)?;
         let vocab_size = vocab.size();
 
-        let model = ParakeetTDTModel::from_pretrained(path, exec_config, vocab_size)?;
+        let model = ParakeetTDTModel::from_pretrained_with_configs(
+            path,
+            exec_config,
+            joint_exec_config,
+            vocab_size,
+        )?;
         let decoder = ParakeetTDTDecoder::from_vocab(vocab);
         let feature_cache = FeatureCache::from_config(&preprocessor_config);
 


### PR DESCRIPTION
The encoder and the decoder/joint are two separate ONNX graphs, but `from_pretrained` gives
them the same `ExecutionConfig`, so they always land on the same execution provider.

That is not always possible. A provider may take one graph and not the other. A QNN runtime
built only for loading precompiled contexts has no graph preparation in it, so the prebuilt
encoder context loads fine and the plain joint graph fails session creation. It fails that way
even where CPU fallback would have taken it.

Where the joint runs is worth deciding separately anyway. It is a small graph that runs once
per token, so the trade is different from the encoder's.

`from_pretrained_with_joint_config` and `from_pretrained_with_configs` take the second config.
The existing constructors pass the same config for both graphs, so nothing changes for current
callers.

AI note: I used an AI assistant for this change. I read it and verified it with
`cargo check --features sortformer`.
