### PR TITLE
Add a per-window session router to Sortformer

### DIFF
--- a/src/sortformer.rs
+++ b/src/sortformer.rs
@@ -41,9 +41,7 @@ const CHUNK_LEN: usize = 124; // Frames per chunk (~10s at 80ms)
 const FIFO_LEN: usize = 124; // FIFO buffer length
 const SPKCACHE_LEN: usize = 188; // Speaker cache length
 const RIGHT_CONTEXT: usize = 1; // Future frames for lookahead
-/// Audio frames -> model frames. Public because it is the only way to relate `chunk_len` to the
-/// mel-frame dimension a graph is pinned to; see [`graph_window`].
-pub const SUBSAMPLING: usize = 8;
+pub const SUBSAMPLING: usize = 8; // Audio frames -> model frames
 const EMB_DIM: usize = 512; // Embedding dimension
 pub const NUM_SPEAKERS: usize = 4; // Model supports 4 speakers
 const FRAME_DURATION: f32 = 0.08; // 80ms per frame
@@ -186,39 +184,24 @@ pub struct RawDiarizationPredictions {
     pub num_valid_frames: usize,
 }
 
-/// The three input dimensions that vary over a stream: `(chunk mel frames, spkcache frames,
-/// fifo frames)`. A graph whose inputs are all fixed serves exactly one of these.
+/// `(chunk mel frames, spkcache frames, fifo frames)` — the input dims that vary over a stream.
 pub type StreamingWindow = (usize, usize, usize);
 
-/// A source of sessions for streaming calls, chosen per window.
-///
-/// [`Sortformer`] owns one session. A graph with symbolic input dimensions accepts every window a
-/// stream produces; a graph with fixed dimensions accepts exactly one, which is what an execution
-/// provider that compiles a whole graph ahead of time needs. A router lets the caller serve the
-/// remaining windows from other graphs — and decide for itself which graph, when to build it and
-/// how long to keep it resident.
-///
-/// `Send + Sync` because [`Sortformer`] is both, and a router becomes part of it — a narrower
-/// bound here would take `Sync` away from every `Sortformer`, router or not.
+/// Supplies a session per streaming window, for graphs with fixed input shapes.
 pub trait SessionRouter: Send + Sync {
-    /// The session to run this call on, or `None` to use the one [`Sortformer`] owns.
-    ///
-    /// Called once per streaming call, before inference. Returning an error fails the call.
+    /// The session for this call, or `None` to use the one [`Sortformer`] owns.
     fn session_for(&mut self, window: StreamingWindow) -> Result<Option<&mut Session>>;
 
-    /// How long the call on `window` spent inside ONNX. Called after every streaming call,
-    /// whichever session served it. Default: ignore.
+    /// Time spent inside ONNX for `window`.
     fn call_finished(&mut self, window: StreamingWindow, elapsed: std::time::Duration) {
         let _ = (window, elapsed);
     }
 
-    /// A new stream is starting, so the windows begin again at the smallest one. Called from
-    /// [`Sortformer::reset_state`]. Default: ignore.
+    /// Called from [`Sortformer::reset_state`].
     fn stream_reset(&mut self) {}
 }
 
-/// The window a graph is pinned to, or `None` if any of the three inputs still has a symbolic
-/// dimension. Read off the graph, never derived from the streaming constants.
+/// The window a graph is pinned to, or `None` if any input dim is symbolic.
 pub fn graph_window(session: &Session) -> Option<StreamingWindow> {
     let dim = |name: &str| -> Option<usize> {
         let shape = session
@@ -229,8 +212,7 @@ pub fn graph_window(session: &Session) -> Option<StreamingWindow> {
             .tensor_shape()?
             .get(1)
             .copied()?;
-        // A pinned zero-length cache is a real window — the first call of every stream has one —
-        // so only a negative (symbolic) dimension counts as unpinned.
+        // A zero-length cache is a real window: every stream's first call has one.
         (shape >= 0).then_some(shape as usize)
     };
     Some((dim("chunk")?, dim("spkcache")?, dim("fifo")?))
@@ -239,7 +221,6 @@ pub fn graph_window(session: &Session) -> Option<StreamingWindow> {
 /// Streaming Sortformer v2 speaker diarization engine
 pub struct Sortformer {
     session: Session,
-    /// Optional per-window session source; `session` serves every call without one.
     router: Option<Box<dyn SessionRouter>>,
     config: DiarizationConfig,
     // Streaming constants (read from ONNX metadata, fallback to defaults)
@@ -330,14 +311,12 @@ impl Sortformer {
         (self.chunk_len + self.right_context) as f32 * FRAME_DURATION
     }
 
-    /// The session this instance owns, for reading the graph it was built from — see
-    /// [`graph_window`].
+    /// The session this instance owns.
     pub fn session(&self) -> &Session {
         &self.session
     }
 
-    /// Serve streaming calls from `router` where it offers a session, and from the one this
-    /// instance owns where it does not.
+    /// Route streaming calls through `router`; calls it declines run on this instance's session.
     pub fn set_session_router(&mut self, router: Box<dyn SessionRouter>) {
         self.router = Some(router);
     }
@@ -648,12 +627,7 @@ impl Sortformer {
         let fifo_value = ort::value::TensorRef::<f32>::from_array_view(fifo_ref.view())?;
         let fifo_lengths_value = ort::value::Value::from_array(fifo_lengths)?;
 
-        // Offer this call's window to the router, if there is one. A graph with fixed input shapes
-        // serves exactly one window, so a stream that runs on such a graph needs somewhere else to
-        // send the windows it does not cover.
         let window = (chunk_feat.shape()[1], spkcache_len, fifo_len);
-        // Nothing measures the call without a router to report it to, so the no-router path pays
-        // for no clock reads.
         let inference_start = self.router.is_some().then(std::time::Instant::now);
         let routed = match self.router.as_mut() {
             Some(router) => router.session_for(window)?,

--- a/src/sortformer.rs
+++ b/src/sortformer.rs
@@ -41,7 +41,9 @@ const CHUNK_LEN: usize = 124; // Frames per chunk (~10s at 80ms)
 const FIFO_LEN: usize = 124; // FIFO buffer length
 const SPKCACHE_LEN: usize = 188; // Speaker cache length
 const RIGHT_CONTEXT: usize = 1; // Future frames for lookahead
-const SUBSAMPLING: usize = 8; // Audio frames -> model frames
+/// Audio frames -> model frames. Public because it is the only way to relate `chunk_len` to the
+/// mel-frame dimension a graph is pinned to; see [`graph_window`].
+pub const SUBSAMPLING: usize = 8;
 const EMB_DIM: usize = 512; // Embedding dimension
 pub const NUM_SPEAKERS: usize = 4; // Model supports 4 speakers
 const FRAME_DURATION: f32 = 0.08; // 80ms per frame
@@ -184,9 +186,60 @@ pub struct RawDiarizationPredictions {
     pub num_valid_frames: usize,
 }
 
+/// The three input dimensions that vary over a stream: `(chunk mel frames, spkcache frames,
+/// fifo frames)`. A graph whose inputs are all fixed serves exactly one of these.
+pub type StreamingWindow = (usize, usize, usize);
+
+/// A source of sessions for streaming calls, chosen per window.
+///
+/// [`Sortformer`] owns one session. A graph with symbolic input dimensions accepts every window a
+/// stream produces; a graph with fixed dimensions accepts exactly one, which is what an execution
+/// provider that compiles a whole graph ahead of time needs. A router lets the caller serve the
+/// remaining windows from other graphs — and decide for itself which graph, when to build it and
+/// how long to keep it resident.
+///
+/// `Send` because [`Sortformer`] is, and a router becomes part of it.
+pub trait SessionRouter: Send {
+    /// The session to run this call on, or `None` to use the one [`Sortformer`] owns.
+    ///
+    /// Called once per streaming call, before inference. Returning an error fails the call.
+    fn session_for(&mut self, window: StreamingWindow) -> Result<Option<&mut Session>>;
+
+    /// How long the call on `window` spent inside ONNX. Called after every streaming call,
+    /// whichever session served it. Default: ignore.
+    fn call_finished(&mut self, window: StreamingWindow, elapsed: std::time::Duration) {
+        let _ = (window, elapsed);
+    }
+
+    /// A new stream is starting, so the windows begin again at the smallest one. Called from
+    /// [`Sortformer::reset_state`]. Default: ignore.
+    fn stream_reset(&mut self) {}
+}
+
+/// The window a graph is pinned to, or `None` if any of the three inputs still has a symbolic
+/// dimension. Read off the graph, never derived from the streaming constants.
+pub fn graph_window(session: &Session) -> Option<StreamingWindow> {
+    let dim = |name: &str| -> Option<usize> {
+        let shape = session
+            .inputs()
+            .iter()
+            .find(|i| i.name() == name)?
+            .dtype()
+            .tensor_shape()?
+            .get(1)
+            .copied()?;
+        // A pinned zero-length cache is a real window — the first call of every stream has one —
+        // so only a negative (symbolic) dimension counts as unpinned.
+        (shape >= 0).then_some(shape as usize)
+    };
+    Some((dim("chunk")?, dim("spkcache")?, dim("fifo")?))
+}
+
 /// Streaming Sortformer v2 speaker diarization engine
 pub struct Sortformer {
     session: Session,
+    /// Optional per-window session source; `session` serves every call without one.
+    router: Option<Box<dyn SessionRouter>>,
     config: DiarizationConfig,
     // Streaming constants (read from ONNX metadata, fallback to defaults)
     pub chunk_len: usize,
@@ -250,6 +303,7 @@ impl Sortformer {
 
         let mut instance = Self {
             session,
+            router: None,
             config,
             chunk_len,
             fifo_len,
@@ -275,8 +329,23 @@ impl Sortformer {
         (self.chunk_len + self.right_context) as f32 * FRAME_DURATION
     }
 
+    /// The session this instance owns, for reading the graph it was built from — see
+    /// [`graph_window`].
+    pub fn session(&self) -> &Session {
+        &self.session
+    }
+
+    /// Serve streaming calls from `router` where it offers a session, and from the one this
+    /// instance owns where it does not.
+    pub fn set_session_router(&mut self, router: Box<dyn SessionRouter>) {
+        self.router = Some(router);
+    }
+
     /// Reset streaming state
     pub fn reset_state(&mut self) {
+        if let Some(router) = self.router.as_mut() {
+            router.stream_reset();
+        }
         self.spkcache = Array3::zeros((1, 0, EMB_DIM));
         self.spkcache_preds = None;
         self.fifo = Array3::zeros((1, 0, EMB_DIM));
@@ -578,9 +647,24 @@ impl Sortformer {
         let fifo_value = ort::value::TensorRef::<f32>::from_array_view(fifo_ref.view())?;
         let fifo_lengths_value = ort::value::Value::from_array(fifo_lengths)?;
 
+        // Offer this call's window to the router, if there is one. A graph with fixed input shapes
+        // serves exactly one window, so a stream that runs on such a graph needs somewhere else to
+        // send the windows it does not cover.
+        let window = (chunk_feat.shape()[1], spkcache_len, fifo_len);
+        let routed = match self.router.as_mut() {
+            Some(router) => router.session_for(window)?,
+            None => None,
+        };
+
+        let inference_start = std::time::Instant::now();
+
         // Run ONNX inference and extract all data in a block to release borrow
         let (preds, new_embs, chunk_len) = {
-            let outputs = self.session.run(ort::inputs!(
+            let session = match routed {
+                Some(session) => session,
+                None => &mut self.session,
+            };
+            let outputs = session.run(ort::inputs!(
                 "chunk" => chunk_value,
                 "chunk_lengths" => chunk_lengths_value,
                 "spkcache" => spkcache_value,
@@ -626,6 +710,10 @@ impl Sortformer {
 
             (preds, new_embs, valid_frames)
         };
+
+        if let Some(router) = self.router.as_mut() {
+            router.call_finished(window, inference_start.elapsed());
+        }
 
         // Extract predictions for different parts
         let fifo_preds = if fifo_len > 0 {

--- a/src/sortformer.rs
+++ b/src/sortformer.rs
@@ -198,8 +198,9 @@ pub type StreamingWindow = (usize, usize, usize);
 /// remaining windows from other graphs — and decide for itself which graph, when to build it and
 /// how long to keep it resident.
 ///
-/// `Send` because [`Sortformer`] is, and a router becomes part of it.
-pub trait SessionRouter: Send {
+/// `Send + Sync` because [`Sortformer`] is both, and a router becomes part of it — a narrower
+/// bound here would take `Sync` away from every `Sortformer`, router or not.
+pub trait SessionRouter: Send + Sync {
     /// The session to run this call on, or `None` to use the one [`Sortformer`] owns.
     ///
     /// Called once per streaming call, before inference. Returning an error fails the call.
@@ -651,12 +652,13 @@ impl Sortformer {
         // serves exactly one window, so a stream that runs on such a graph needs somewhere else to
         // send the windows it does not cover.
         let window = (chunk_feat.shape()[1], spkcache_len, fifo_len);
+        // Nothing measures the call without a router to report it to, so the no-router path pays
+        // for no clock reads.
+        let inference_start = self.router.is_some().then(std::time::Instant::now);
         let routed = match self.router.as_mut() {
             Some(router) => router.session_for(window)?,
             None => None,
         };
-
-        let inference_start = std::time::Instant::now();
 
         // Run ONNX inference and extract all data in a block to release borrow
         let (preds, new_embs, chunk_len) = {
@@ -711,8 +713,8 @@ impl Sortformer {
             (preds, new_embs, valid_frames)
         };
 
-        if let Some(router) = self.router.as_mut() {
-            router.call_finished(window, inference_start.elapsed());
+        if let (Some(router), Some(started)) = (self.router.as_mut(), inference_start) {
+            router.call_finished(window, started.elapsed());
         }
 
         // Extract predictions for different parts

--- a/tests/auto_traits.rs
+++ b/tests/auto_traits.rs
@@ -1,5 +1,4 @@
-//! Sortformer is Send + Sync. A session router becomes part of it, so its trait bounds have to
-//! keep both — this fails to compile if they ever stop doing so.
+//! A session router becomes part of Sortformer, so its bounds have to keep both auto traits.
 
 fn assert_send<T: Send>() {}
 fn assert_sync<T: Sync>() {}

--- a/tests/auto_traits.rs
+++ b/tests/auto_traits.rs
@@ -1,0 +1,11 @@
+//! Sortformer is Send + Sync. A session router becomes part of it, so its trait bounds have to
+//! keep both — this fails to compile if they ever stop doing so.
+
+fn assert_send<T: Send>() {}
+fn assert_sync<T: Sync>() {}
+
+#[test]
+fn sortformer_is_send_and_sync() {
+    assert_send::<parakeet_rs::sortformer::Sortformer>();
+    assert_sync::<parakeet_rs::sortformer::Sortformer>();
+}

--- a/tests/auto_traits.rs
+++ b/tests/auto_traits.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "sortformer")]
+
 //! A session router becomes part of Sortformer, so its bounds have to keep both auto traits.
 
 fn assert_send<T: Send>() {}


### PR DESCRIPTION
Closes #122, where you reviewed the branch. Both of your points are fixed in the second commit.

**1. The clock.** You are right, `Instant::now()` ran on every call. It is only read when a router is attached now:

```rust
let inference_start = self.router.is_some().then(std::time::Instant::now);
```

Without a router the path costs what it did before.

**2. `Sync`.** Good catch, and it was not intentional. I checked `master` first: `Sortformer` is `Send + Sync` there. With a `Send`-only bound my branch took `Sync` away from every `Sortformer`, with a router or without one. So it was not only about the router type.

The bound is `Send + Sync` now. I did not have to relax anything on my side, my own router already satisfied it. I also added `tests/auto_traits.rs`, which stops compiling if either trait is lost again.

Short recap of the change itself, now that it is two commits:

- `SessionRouter` is asked once per streaming call. Return a session and it runs the call, return `None` and the normal session does. No router means no change.
- `call_finished` and `stream_reset` have default empty bodies.
- `graph_window()`, `session()` and a public `SUBSAMPLING` let a caller read which window a graph is pinned to instead of guessing it from the streaming constants.

`cargo check`, `cargo clippy` and `cargo test --features sortformer` are clean.

AI note: I used an AI assistant while writing this patch. I read it, I understand it, and I verified it as described.
