### PR TITLE
Remove the now-unused ParakeetTDTModel::from_pretrained

### DIFF
--- a/src/model_tdt.rs
+++ b/src/model_tdt.rs
@@ -24,21 +24,6 @@ pub struct ParakeetTDTModel {
 }
 
 impl ParakeetTDTModel {
-    /// Load TDT model from directory containing encoder and decoder_joint ONNX files
-    ///
-    /// # Arguments
-    /// * `model_dir` - Directory containing encoder and decoder_joint ONNX files
-    /// * `exec_config` - Execution configuration for ONNX runtime
-    /// * `vocab_size` - Vocabulary size (number of tokens including blank)
-    pub fn from_pretrained<P: AsRef<Path>>(
-        model_dir: P,
-        exec_config: ExecutionConfig,
-        vocab_size: usize,
-    ) -> Result<Self> {
-        let joint_config = exec_config.clone();
-        Self::from_pretrained_with_configs(model_dir, exec_config, joint_config, vocab_size)
-    }
-
     /// Load a TDT model, running the encoder and the decoder/joint under separate execution
     /// configurations.
     ///


### PR DESCRIPTION
I introduced this in #121. Once `ParakeetTDT` started calling `from_pretrained_with_configs`, the single-config `ParakeetTDTModel::from_pretrained` lost its only caller, and `model_tdt` is a private module, so it cannot be reached from outside the crate either. `cargo clippy` has been reporting it as dead code since that merge.

The public `ParakeetTDT::from_pretrained` is untouched.

Sorry for the noise, I should have caught it in the original PR.

AI note: I used an AI assistant for this change. I read it and verified it with `cargo clippy --features sortformer`.
