### PR TITLE
Trim the explanatory comments from the diarize split

### DIFF
--- a/src/sortformer.rs
+++ b/src/sortformer.rs
@@ -291,9 +291,6 @@ impl Sortformer {
     /// Mel extraction and streaming inference, returning raw per-frame speaker probabilities with
     /// no post-processing applied.
     ///
-    /// Split out of [`Sortformer::diarize`] so that a different backend can supply an equivalent
-    /// `[num_frames, NUM_SPEAKERS]` matrix and reuse [`Sortformer::post_process`] unchanged.
-    ///
     /// # Returns
     /// `(predictions [num_frames, NUM_SPEAKERS], mono sample count)`
     pub fn predict_raw(
@@ -329,11 +326,7 @@ impl Sortformer {
     }
 
     /// Median-smooth and binarize raw per-frame speaker probabilities into segments, clipped to
-    /// the audio length.
-    ///
-    /// Takes the config explicitly and depends only on the `[num_frames, NUM_SPEAKERS]` matrix, so
-    /// it runs without a session and a backend that is not this ONNX one gets byte-identical
-    /// post-processing.
+    /// the audio length. Needs no session.
     pub fn post_process(
         config: &DiarizationConfig,
         preds: &Array2<f32>,
@@ -1046,8 +1039,6 @@ impl Sortformer {
     }
 
     /// Apply median filter to predictions
-    /// Takes the config explicitly rather than `&self` so [`Sortformer::post_process`] can run
-    /// without a session.
     fn median_filter(config: &DiarizationConfig, preds: &Array2<f32>) -> Array2<f32> {
         let window = config.median_window;
         let half = window / 2;
@@ -1069,8 +1060,6 @@ impl Sortformer {
     }
 
     /// Binarize predictions to segments (padding applied during thresholding)
-    /// Takes the config explicitly rather than `&self` so [`Sortformer::post_process`] can run
-    /// without a session.
     fn binarize(config: &DiarizationConfig, preds: &Array2<f32>) -> Vec<SpeakerSegment> {
         let mut segments = Vec::new();
         let num_frames = preds.shape()[0];


### PR DESCRIPTION
Following your note on #123, for the parts I thought were excessive.

- `predict_raw` — dropped the paragraph about why it was split out. The first line and `# Returns` stay.
- `post_process` — the rationale paragraph became four words: "Needs no session." That part is worth keeping as a fact about the function, the rest was explanation.
- `median_filter` and `binarize` — both comments removed. They said the config comes in as a parameter, which the signature already says, and both are private anyway.

I left everything else alone.

`cargo test` passes with default features and with `--features sortformer`, clippy is clean.

AI note: I used an AI assistant for this change, and verified it as above.
